### PR TITLE
Run meta content provider against watcher-operator

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -1,0 +1,9 @@
+---
+- project:
+    name: openstack-k8s-operators/watcher-operator
+    default-branch: main
+    github-check:
+      jobs:
+        - openstack-meta-content-provider:
+            vars:
+              cifmw_operator_build_meta_build: false


### PR DESCRIPTION
Since watcher-operator is currently standalone operator. So we are only building watcher-operator and skipping meta operator build.

Depends-On: https://github.com/openstack-k8s-operators/ci-framework/pull/2529
Depends-On: https://github.com/openstack-k8s-operators/watcher-operator/pull/2