### PR TITLE
Add github workflow to build and push watcher operator images

### DIFF
--- a/.github/workflows/build-watcher-operator.yaml
+++ b/.github/workflows/build-watcher-operator.yaml
@@ -1,0 +1,25 @@
+name: watcher operator image builder
+
+on:
+  push:
+    branches:
+      - '*'
+
+env:
+  imageregistry: 'quay.io'
+  imagenamespace: ${{ secrets.IMAGENAMESPACE || secrets.QUAY_USERNAME }}
+  latesttag: latest
+
+jobs:
+  call-build-workflow:
+    uses: openstack-k8s-operators/openstack-k8s-operators-ci/.github/workflows/reusable-build-operator.yaml@main
+    with:
+      operator_name: watcher
+      go_version: 1.21.x
+      operator_sdk_version: 1.31.0
+    secrets:
+      IMAGENAMESPACE: ${{ secrets.IMAGENAMESPACE }}
+      QUAY_USERNAME: ${{ secrets.QUAY_USERNAME }}
+      QUAY_PASSWORD: ${{ secrets.QUAY_PASSWORD }}
+      REDHATIO_USERNAME: ${{ secrets.REDHATIO_USERNAME }}
+      REDHATIO_PASSWORD: ${{ secrets.REDHATIO_PASSWORD }}


### PR DESCRIPTION
This is based on nova operator workflow. It will build the images once a pr gets merged.

Jira: https://issues.redhat.com/browse/OSPRH-11419