### PR TITLE
Add watcher target to deploy operator via olm

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,6 @@ CI_TOOLS_REPO
 *.swp
 *.swo
 *~
+
+# CI generated files
+ci/olm.yaml

--- a/README.md
+++ b/README.md
@@ -66,6 +66,42 @@ make uninstall
 make undeploy
 ```
 
+### To Deploy via OLM
+
+**Deploy watcher-operator via olm
+
+```sh
+make watcher
+```
+
+**Deply watcher-operator via olm with different catalog image
+
+```sh
+make watcher CATALOG_IMAGE=<catalog image url with tag>
+```
+
+#### To Deploy watcher service
+
+**Deploy watcher service
+
+```sh
+make watcher_deploy
+```
+
+### To Uninstall OLM deployed watcher-operator
+
+**Undeploy watcher service
+
+```sh
+make watcher_deploy_cleanup
+```
+
+**Uninstall watcher-operator
+
+```sh
+make watcher_cleanup
+```
+
 ## Project Distribution
 
 Following are the steps to build the installer and distribute this project to users.

--- a/ci/olm.sh
+++ b/ci/olm.sh
@@ -1,0 +1,36 @@
+cat > ci/olm.yaml <<EOF_CAT
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+    name: openstack-operators
+    labels:
+      pod-security.kubernetes.io/enforce: privileged
+      security.openshift.io/scc.podSecurityLabelSync: "false"
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: CatalogSource
+metadata:
+  name: watcher-operator-index
+  namespace: openstack-operators
+spec:
+  image: ${CATALOG_IMG}
+  sourceType: grpc
+---
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: openstack
+  namespace: openstack-operators
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: watcher-operator
+  namespace: openstack-operators
+spec:
+  name: watcher-operator
+  channel: alpha
+  source: watcher-operator-index
+  sourceNamespace: openstack-operators
+EOF_CAT


### PR DESCRIPTION
 This pr adds two targets:
    * `make watcher`: It generates olm.yaml file and installs the
      watcher-operator using oc.
    * `make watcher_cleanup`: It generates the olm.yaml file and undeploy
      the watcher-operator using oc.
    
 It also provides $CATALOG_IMAGE var to pass custom watcher-operator index image.


Jira: https://issues.redhat.com/browse/OSPRH-11419