### PR TITLE
Zuul job to validate watcher deployment

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -7,3 +7,33 @@
         - openstack-meta-content-provider:
             vars:
               cifmw_operator_build_meta_build: false
+        - watcher-operator-validation
+
+- job:
+    name: watcher-operator-base
+    parent: podified-multinode-edpm-deployment-crc-2comp
+    dependencies: ["openstack-meta-content-provider"]
+    description: |
+      A multinode EDPM Zuul job which has one ansible controller, one
+      extracted crc and two computes. It will be used for testing watcher-operator.
+    vars:
+      watcher_repo: "{{ ansible_user_dir }}/src/github.com/openstack-k8s-operators/watcher-operator"
+      watcher_hook: "{{ watcher_repo }}/ci/playbooks/deploy_watcher_service.yaml"
+      cifmw_install_yamls_whitelisted_vars:
+        - 'WATCHER_REPO'
+        - 'WATCHER_BRANCH'
+        - 'OUTPUT_DIR'
+      post_deploy:
+        - name: Deploy watcher service
+          type: playbook
+          source: "{{ watcher_hook }}"
+          extra_vars:
+            watcher_catalog_image: "{{ content_provider_registry_ip }}:5001/openstack-k8s-operators/watcher-operator-index:{{ zuul.patchset }}"
+
+- job:
+    name: watcher-operator-validation
+    parent: watcher-operator-base
+    description: |
+      A zuul job to validate the watcher operator and its service deployment.
+    vars:
+      run_tempest: false

--- a/ci/playbooks/deploy_watcher_service.yaml
+++ b/ci/playbooks/deploy_watcher_service.yaml
@@ -1,0 +1,23 @@
+---
+# This hook is used to deploy watcher service.
+
+- name: Deploy Watcher service
+  hosts: "{{ cifmw_target_hook_host | default('localhost') }}"
+  gather_facts: false
+  environment:
+    KUBECONFIG: "{{ cifmw_openshift_kubeconfig }}"
+    PATH: "{{ cifmw_path }}"
+  tasks:
+    - name: Install Watcher Operator
+      cifmw.general.ci_script:
+        output_dir: "{{ cifmw_basedir }}/artifacts"
+        chdir: "{{ ansible_user_dir }}/src/github.com/openstack-k8s-operators/watcher-operator"
+        script: make watcher
+        extra_args:
+          CATALOG_IMAGE: "{{ watcher_catalog_image | default('quay.io/openstack-k8s-operators/watcher-operator-index:latest') }}"
+
+    - name: Deploy Watcher service
+      cifmw.general.ci_script:
+        output_dir: "{{ cifmw_basedir }}/artifacts"
+        chdir: "{{ ansible_user_dir }}/src/github.com/openstack-k8s-operators/watcher-operator"
+        script: make watcher_deploy


### PR DESCRIPTION
This pr:
- Adds watcher-operator-base job from
  podified-multinode-edpm-deployment-crc-2comp parent. This job will
  deploy 2 node EDPM deployment and then deploy watcher operator using
  make targets from watcher-operator repo.
- It adds hook to deploy watcher service via ci-framework hook.

Test Results: https://github.com/openstack-k8s-operators/watcher-operator/pull/9#issuecomment-2499701046 

Depends-On: https://github.com/openstack-k8s-operators/watcher-operator/pull/11
Depends-On: https://github.com/openstack-k8s-operators/ci-framework/pull/2569