### PR TITLE
Fix controller manager label

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -3,7 +3,6 @@ kind: Namespace
 metadata:
   labels:
     control-plane: controller-manager
-    app.kubernetes.io/name: watcher-operator
     app.kubernetes.io/managed-by: kustomize
   name: system
 ---
@@ -14,12 +13,12 @@ metadata:
   namespace: system
   labels:
     control-plane: controller-manager
-    app.kubernetes.io/name: watcher-operator
+    openstack.org/operator-name: watcher
     app.kubernetes.io/managed-by: kustomize
 spec:
   selector:
     matchLabels:
-      control-plane: controller-manager
+      openstack.org/operator-name: watcher
   replicas: 1
   template:
     metadata:
@@ -27,6 +26,7 @@ spec:
         kubectl.kubernetes.io/default-container: manager
       labels:
         control-plane: controller-manager
+        openstack.org/operator-name: watcher
     spec:
       # TODO(user): Uncomment the following code to configure the nodeAffinity expression
       # according to the platforms which are supported by your solution.

--- a/config/prometheus/monitor.yaml
+++ b/config/prometheus/monitor.yaml
@@ -4,7 +4,6 @@ kind: ServiceMonitor
 metadata:
   labels:
     control-plane: controller-manager
-    app.kubernetes.io/name: watcher-operator
     app.kubernetes.io/managed-by: kustomize
   name: controller-manager-metrics-monitor
   namespace: system
@@ -18,4 +17,4 @@ spec:
         insecureSkipVerify: true
   selector:
     matchLabels:
-      control-plane: controller-manager
+      openstack.org/operator-name: watcher

--- a/config/rbac/auth_proxy_service.yaml
+++ b/config/rbac/auth_proxy_service.yaml
@@ -3,7 +3,6 @@ kind: Service
 metadata:
   labels:
     control-plane: controller-manager
-    app.kubernetes.io/name: watcher-operator
     app.kubernetes.io/managed-by: kustomize
   name: controller-manager-metrics-service
   namespace: system
@@ -14,4 +13,4 @@ spec:
     protocol: TCP
     targetPort: https
   selector:
-    control-plane: controller-manager
+    openstack.org/operator-name: watcher


### PR DESCRIPTION
In all the openstack-operators, openstack.org/operator-name label is used. The same needs to be used in watcher-operator. Otherwise During log collection, ci-framework env_op_images role fails while querying all controller manager pods.

This pr adds openstack.org/operator-name: watcher label to the operator.