### PR TITLE
Create reconcilers consistently from watcher_common and add timeout

### DIFF
--- a/controllers/watcher_common.go
+++ b/controllers/watcher_common.go
@@ -1,0 +1,98 @@
+package controllers
+
+import (
+	"context"
+	"time"
+
+	"github.com/go-logr/logr"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+// GetLogger returns a logger object with a prefix of "controller.name" and additional controller context fields
+func (r *ReconcilerBase) GetLogger(ctx context.Context) logr.Logger {
+	return log.FromContext(ctx).WithName("Controllers").WithName("ReconcilerBase")
+}
+
+// ReconcilerBase provides a common set of clients scheme and loggers for all reconcilers.
+type ReconcilerBase struct {
+	Client         client.Client
+	Kclient        kubernetes.Interface
+	Scheme         *runtime.Scheme
+	RequeueTimeout time.Duration
+}
+
+// Manageable all types that conform to this interface can be setup with a controller-runtime manager.
+type Manageable interface {
+	SetupWithManager(mgr ctrl.Manager) error
+}
+
+// Reconciler represents a generic interface for all Reconciler objects in watcher
+type Reconciler interface {
+	Manageable
+	SetRequeueTimeout(timeout time.Duration)
+}
+
+// NewReconcilerBase constructs a ReconcilerBase given a manager and Kclient.
+func NewReconcilerBase(
+	mgr ctrl.Manager, kclient kubernetes.Interface,
+) ReconcilerBase {
+	return ReconcilerBase{
+		Client:         mgr.GetClient(),
+		Scheme:         mgr.GetScheme(),
+		Kclient:        kclient,
+		RequeueTimeout: time.Duration(5) * time.Second,
+	}
+}
+
+// SetRequeueTimeout overrides the default RequeueTimeout of the Reconciler
+func (r *ReconcilerBase) SetRequeueTimeout(timeout time.Duration) {
+	r.RequeueTimeout = timeout
+}
+
+// Reconcilers holds all the Reconciler objects of the watcher-operator to
+// allow generic management of them.
+type Reconcilers struct {
+	reconcilers map[string]Reconciler
+}
+
+// NewReconcilers constructs all watcher Reconciler objects
+func NewReconcilers(mgr ctrl.Manager, kclient *kubernetes.Clientset) *Reconcilers {
+	return &Reconcilers{
+		reconcilers: map[string]Reconciler{
+			"Watcher": &WatcherReconciler{
+				ReconcilerBase: NewReconcilerBase(mgr, kclient),
+			},
+			"WatcherAPI": &WatcherAPIReconciler{
+				ReconcilerBase: NewReconcilerBase(mgr, kclient),
+			},
+			"WatcherDecisionEngine": &WatcherDecisionEngineReconciler{
+				ReconcilerBase: NewReconcilerBase(mgr, kclient),
+			},
+			"WatcherApplier": &WatcherApplierReconciler{
+				ReconcilerBase: NewReconcilerBase(mgr, kclient),
+			},
+		}}
+}
+
+// Setup starts the reconcilers by connecting them to the Manager
+func (r *Reconcilers) Setup(mgr ctrl.Manager, setupLog logr.Logger) error {
+	var err error
+	for name, controller := range r.reconcilers {
+		if err = controller.SetupWithManager(mgr); err != nil {
+			setupLog.Error(err, "unable to create controller", "controller", name)
+			return err
+		}
+	}
+	return nil
+}
+
+// OverrideRequeueTimeout overrides the default RequeueTimeout of our reconcilers
+func (r *Reconcilers) OverrideRequeueTimeout(timeout time.Duration) {
+	for _, reconciler := range r.reconcilers {
+		reconciler.SetRequeueTimeout(timeout)
+	}
+}

--- a/controllers/watcher_controller.go
+++ b/controllers/watcher_controller.go
@@ -266,7 +266,7 @@ func (r *WatcherReconciler) ensureDB(
 		return db, ctrlResult, nil
 	}
 	// wait for the DB to be setup
-	ctrlResult, err = db.WaitForDBCreated(ctx, h)
+	ctrlResult, err = db.WaitForDBCreatedWithTimeout(ctx, h, r.RequeueTimeout)
 	if err != nil {
 		instance.Status.Conditions.Set(condition.FalseCondition(
 			condition.DBReadyCondition,

--- a/controllers/watcher_controller.go
+++ b/controllers/watcher_controller.go
@@ -20,10 +20,7 @@ import (
 	"context"
 	"fmt"
 
-	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/client-go/kubernetes"
 	ctrl "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
@@ -41,9 +38,7 @@ import (
 
 // WatcherReconciler reconciles a Watcher object
 type WatcherReconciler struct {
-	client.Client
-	Kclient kubernetes.Interface
-	Scheme  *runtime.Scheme
+	ReconcilerBase
 }
 
 // GetLogger returns a logger object with a prefix of "controller.name" and additional controller context fields

--- a/controllers/watcherapi_controller.go
+++ b/controllers/watcherapi_controller.go
@@ -19,9 +19,7 @@ package controllers
 import (
 	"context"
 
-	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	watcherv1beta1 "github.com/openstack-k8s-operators/watcher-operator/api/v1beta1"
@@ -29,8 +27,7 @@ import (
 
 // WatcherAPIReconciler reconciles a WatcherAPI object
 type WatcherAPIReconciler struct {
-	client.Client
-	Scheme *runtime.Scheme
+	ReconcilerBase
 }
 
 //+kubebuilder:rbac:groups=watcher.openstack.org,resources=watcherapis,verbs=get;list;watch;create;update;patch;delete

--- a/controllers/watcherapplier_controller.go
+++ b/controllers/watcherapplier_controller.go
@@ -19,9 +19,7 @@ package controllers
 import (
 	"context"
 
-	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	watcherv1beta1 "github.com/openstack-k8s-operators/watcher-operator/api/v1beta1"
@@ -29,8 +27,7 @@ import (
 
 // WatcherApplierReconciler reconciles a WatcherApplier object
 type WatcherApplierReconciler struct {
-	client.Client
-	Scheme *runtime.Scheme
+	ReconcilerBase
 }
 
 //+kubebuilder:rbac:groups=watcher.openstack.org,resources=watcherappliers,verbs=get;list;watch;create;update;patch;delete

--- a/controllers/watcherdecisionengine_controller.go
+++ b/controllers/watcherdecisionengine_controller.go
@@ -19,9 +19,7 @@ package controllers
 import (
 	"context"
 
-	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	watcherv1beta1 "github.com/openstack-k8s-operators/watcher-operator/api/v1beta1"
@@ -29,8 +27,7 @@ import (
 
 // WatcherDecisionEngineReconciler reconciles a WatcherDecisionEngine object
 type WatcherDecisionEngineReconciler struct {
-	client.Client
-	Scheme *runtime.Scheme
+	ReconcilerBase
 }
 
 //+kubebuilder:rbac:groups=watcher.openstack.org,resources=watcherdecisionengines,verbs=get;list;watch;create;update;patch;delete

--- a/main.go
+++ b/main.go
@@ -137,36 +137,11 @@ func main() {
 		os.Exit(1)
 	}
 
-	if err = (&controllers.WatcherAPIReconciler{
-		Client: mgr.GetClient(),
-		Scheme: mgr.GetScheme(),
-	}).SetupWithManager(mgr); err != nil {
-		setupLog.Error(err, "unable to create controller", "controller", "WatcherAPI")
+	reconcilers := controllers.NewReconcilers(mgr, kclient)
+	err = reconcilers.Setup(mgr, setupLog)
+	if err != nil {
 		os.Exit(1)
 	}
-	if err = (&controllers.WatcherReconciler{
-		Client:  mgr.GetClient(),
-		Kclient: kclient,
-		Scheme:  mgr.GetScheme(),
-	}).SetupWithManager(mgr); err != nil {
-		setupLog.Error(err, "unable to create controller", "controller", "Watcher")
-		os.Exit(1)
-	}
-	if err = (&controllers.WatcherDecisionEngineReconciler{
-		Client: mgr.GetClient(),
-		Scheme: mgr.GetScheme(),
-	}).SetupWithManager(mgr); err != nil {
-		setupLog.Error(err, "unable to create controller", "controller", "WatcherDecisionEngine")
-		os.Exit(1)
-	}
-	if err = (&controllers.WatcherApplierReconciler{
-		Client: mgr.GetClient(),
-		Scheme: mgr.GetScheme(),
-	}).SetupWithManager(mgr); err != nil {
-		setupLog.Error(err, "unable to create controller", "controller", "WatcherApplier")
-		os.Exit(1)
-	}
-	//+kubebuilder:scaffold:builder
 
 	if err := mgr.AddHealthzCheck("healthz", healthz.Ping); err != nil {
 		setupLog.Error(err, "unable to set up health check")


### PR DESCRIPTION
This is implementing a mechanism to create the reconcilers consistently similar to the one used in nova-operator.

It is also including a RequeueTimeout parameter which can be used in the lower level calls to avoid that controller gets blocked at some point.

This PR is also implementing this timeout when waiting for the DB to be created.
