### PR TITLE
Add secret and services to controller rbac

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -6,6 +6,30 @@ metadata:
   name: manager-role
 rules:
 - apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - services
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
   - mariadb.openstack.org
   resources:
   - mariadbaccounts

--- a/controllers/watcher_controller.go
+++ b/controllers/watcher_controller.go
@@ -61,6 +61,8 @@ func (r *WatcherReconciler) GetLogger(ctx context.Context) logr.Logger {
 //+kubebuilder:rbac:groups=mariadb.openstack.org,resources=mariadbaccounts,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=mariadb.openstack.org,resources=mariadbaccounts/finalizers,verbs=update
 //+kubebuilder:rbac:groups=mariadb.openstack.org,resources=mariadbdatabases,verbs=get;list;watch;create;update;patch;delete;
+//+kubebuilder:rbac:groups=core,resources=secrets,verbs=get;list;watch;create;update;patch;delete;
+//+kubebuilder:rbac:groups=core,resources=services,verbs=get;list;watch;create;update;patch;delete;
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.


### PR DESCRIPTION
While trying to run kuttl tests in [1], we get an error [2]
stating that the watcher controller does not have access to secrets.
This change adds the required kubebuilder annotations for secrets in the
watcher controller. Similarly, we are also missing access to services
[3].

[1] https://github.com/openstack-k8s-operators/watcher-operator/pull/14
[2] https://logserver.rdoproject.org/14/14/693d9a4c2c6b2630ef004bcd34b0bf3076826174/github-check/watcher-operator-kuttl/12efc41/controller/ci-framework-data/logs/openstack-k8s-operators-openstack-must-gather/namespaces/openstack-operators/pods/watcher-operator-controller-manager-84c899877f-wjsx8/logs/manager.log
[3] https://logserver.rdoproject.org/14/14/693d9a4c2c6b2630ef004bcd34b0bf3076826174/github-check/watcher-operator-kuttl/1968261/controller/ci-framework-data/logs/openstack-k8s-operators-openstack-must-gather/namespaces/openstack-operators/pods/watcher-operator-controller-manager-67dbb9c5d5-t25z6/logs/manager.log
