### PR TITLE
Disable workflow on forked repos

### DIFF
--- a/.github/workflows/build-watcher-operator.yaml
+++ b/.github/workflows/build-watcher-operator.yaml
@@ -12,6 +12,8 @@ env:
 
 jobs:
   call-build-workflow:
+    # Disable workflow on forked repos
+    if: github.repository == 'openstack-k8s-operators/watcher-operator'
     uses: openstack-k8s-operators/openstack-k8s-operators-ci/.github/workflows/reusable-build-operator.yaml@main
     with:
       operator_name: watcher

--- a/.github/workflows/noop.yml
+++ b/.github/workflows/noop.yml
@@ -17,6 +17,8 @@ on:
 jobs:
   # This workflow contains a single job called "build"
   build:
+    # Disable github workflow on forked repo
+    if: github.repository == 'openstack-k8s-operators/watcher-operator'
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
Currently Devs are receiving github action workflow run email on each push on their forked repos. It is quite annoying.

Based on https://github.com/orgs/community/discussions/26704, We can disable the workflow manually or add specific condition to run workflow on forked repo.

It got skipped on my forked repo. 
![image](https://github.com/user-attachments/assets/95a9f11c-d423-4855-b59e-1c5a5c1ccb37)

Depends-On: https://github.com/openstack-k8s-operators/watcher-operator/pull/21
