### PR TITLE
Disable some rules for crd schema check

### DIFF
--- a/hack/crd-schema-checker.sh
+++ b/hack/crd-schema-checker.sh
@@ -17,5 +17,6 @@ for crd in config/crd/bases/*.yaml; do
     git show "$BASE_REF:$crd" > "$TMP_DIR/$crd"
     $CHECKER check-manifests \
         --existing-crd-filename="$TMP_DIR/$crd" \
+        --disabled-validators="NoFieldRemoval,NoNewRequiredFields,ConditionsMustHaveProperSSATags,ListsMustHaveSSATags" \
         --new-crd-filename="$crd"
 done


### PR DESCRIPTION
NoFieldRemoval and NoNewRequiredFields need to be temporarily disabled
since we're currently building the crds as we go.
ConditionsMustHaveProperSSATags and ListsMustHaveSSATags are disabled
beacuse they affect the Conditions type defined in lib-common, so they
are not specific to watcher-operator.
