### PR TITLE
Follow-up changes for WatcherAPI from PR 13

### DIFF
--- a/api/bases/watcher.openstack.org_watcherapis.yaml
+++ b/api/bases/watcher.openstack.org_watcherapis.yaml
@@ -62,7 +62,6 @@ spec:
                     type: string
                 type: object
               secret:
-                default: osp-secret
                 description: Secret containing all passwords / keys needed
                 type: string
               serviceUser:
@@ -72,6 +71,7 @@ spec:
                 type: string
             required:
             - databaseInstance
+            - secret
             type: object
           status:
             description: WatcherAPIStatus defines the observed state of WatcherAPI

--- a/api/v1beta1/common_types.go
+++ b/api/v1beta1/common_types.go
@@ -18,10 +18,6 @@ package v1beta1
 
 // WatcherCommon defines a spec based reusable for all the CRDs
 type WatcherCommon struct {
-	// +kubebuilder:validation:Optional
-	// +kubebuilder:default=osp-secret
-	// Secret containing all passwords / keys needed
-	Secret string `json:"secret"`
 
 	// +kubebuilder:validation:Optional
 	// +kubebuilder:default=watcher
@@ -55,6 +51,11 @@ type WatcherTemplate struct {
 	// RabbitMQ instance name
 	// Needed to request a transportURL that is created and used in Barbican
 	RabbitMqClusterName string `json:"rabbitMqClusterName"`
+
+	// +kubebuilder:validation:Optional
+	// +kubebuilder:default=osp-secret
+	// Secret containing all passwords / keys needed
+	Secret string `json:"secret"`
 }
 
 // PasswordSelector to identify the DB and AdminUser password from the Secret

--- a/api/v1beta1/watcherapi_types.go
+++ b/api/v1beta1/watcherapi_types.go
@@ -27,6 +27,9 @@ type WatcherAPISpec struct {
 	// Important: Run "make" to regenerate code after modifying this file
 
 	WatcherCommon `json:",inline"`
+	// +kubebuilder:validation:Required
+	// Secret containing all passwords / keys needed
+	Secret string `json:"secret"`
 }
 
 // WatcherAPIStatus defines the observed state of WatcherAPI

--- a/config/crd/bases/watcher.openstack.org_watcherapis.yaml
+++ b/config/crd/bases/watcher.openstack.org_watcherapis.yaml
@@ -62,7 +62,6 @@ spec:
                     type: string
                 type: object
               secret:
-                default: osp-secret
                 description: Secret containing all passwords / keys needed
                 type: string
               serviceUser:
@@ -72,6 +71,7 @@ spec:
                 type: string
             required:
             - databaseInstance
+            - secret
             type: object
           status:
             description: WatcherAPIStatus defines the observed state of WatcherAPI

--- a/config/samples/watcher_v1beta1_watcherapi.yaml
+++ b/config/samples/watcher_v1beta1_watcherapi.yaml
@@ -7,3 +7,4 @@ metadata:
   name: watcherapi-sample
 spec:
   databaseInstance: "openstack"
+  secret: "osp-secret"

--- a/controllers/watcherapi_controller.go
+++ b/controllers/watcherapi_controller.go
@@ -152,11 +152,11 @@ func (r *WatcherAPIReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 	db, err := mariadbv1.GetDatabaseByNameAndAccount(ctx, helper, watcher.DatabaseCRName, instance.Spec.DatabaseAccount, instance.Namespace)
 	if err != nil {
 		instance.Status.Conditions.Set(condition.FalseCondition(
-			condition.ServiceConfigReadyCondition,
+			condition.InputReadyCondition,
 			condition.ErrorReason,
 			condition.SeverityWarning,
-			condition.ServiceConfigReadyErrorMessage,
-			err.Error()))
+			condition.InputReadyErrorMessage,
+			fmt.Sprintf("couldn't get database %s and account %s", watcher.DatabaseCRName, instance.Spec.DatabaseAccount)))
 		return ctrl.Result{}, err
 	}
 

--- a/tests/kuttl/test-suites/default/watcher-api/01-cleanup-watcherapi.yaml
+++ b/tests/kuttl/test-suites/default/watcher-api/01-cleanup-watcherapi.yaml
@@ -4,3 +4,6 @@ delete:
 - apiVersion: watcher.openstack.org/v1beta1
   kind: WatcherAPI
   name: watcherapi-kuttl
+- apiVersion: v1
+  kind: Secret
+  name: watcherapi-secret

--- a/tests/kuttl/test-suites/default/watcher-api/03-assert.yaml
+++ b/tests/kuttl/test-suites/default/watcher-api/03-assert.yaml
@@ -9,7 +9,7 @@ spec:
   databaseInstance: openstack
   passwordSelectors:
     service: WatcherPassword
-  secret: osp-secret
+  secret: watcherapi-secret
 status:
   conditions:
   - message: Setup complete

--- a/tests/kuttl/test-suites/default/watcher-api/03-deploy-watcher-api.yaml
+++ b/tests/kuttl/test-suites/default/watcher-api/03-deploy-watcher-api.yaml
@@ -1,6 +1,15 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: watcherapi-secret
+type: Opaque
+stringData:
+  WatcherPassword: password
+---
 apiVersion: watcher.openstack.org/v1beta1
 kind: WatcherAPI
 metadata:
   name: watcherapi-kuttl
 spec:
-  databaseInstance: "openstack"
+  databaseInstance: openstack
+  secret: watcherapi-secret


### PR DESCRIPTION
Following the review on PR 13, there were a few changes suggested. This
PR does 2 of them:

1. Make the Secret field on the Spec required, and remove the default
   from WatcherAPI. This means that the field is no longer shared
   between the Watcher and WatcherAPI kinds.

2. Add more functional tests to test scenarios where the secret or
   database are not present.
   
   Related: [OSPRH-11483](https://issues.redhat.com//browse/OSPRH-11483)
