### PR TITLE
Create internal secret to consume in sub-crs

### DIFF
--- a/api/bases/watcher.openstack.org_watcherapis.yaml
+++ b/api/bases/watcher.openstack.org_watcherapis.yaml
@@ -43,16 +43,6 @@ spec:
                 description: The service specific Container Image URL (will be set
                   to environmental default if empty)
                 type: string
-              databaseAccount:
-                default: watcher
-                description: DatabaseAccount - MariaDBAccount CR name used for watcher
-                  DB, defaults to watcher
-                type: string
-              databaseInstance:
-                description: |-
-                  MariaDB instance name
-                  Required to use the mariadb-operator instance to create the DB and user
-                type: string
               memcachedInstance:
                 default: memcached
                 description: MemcachedInstance is the name of the Memcached CR that
@@ -84,7 +74,6 @@ spec:
                   to register in keystone
                 type: string
             required:
-            - databaseInstance
             - secret
             type: object
           status:

--- a/api/v1beta1/common_types.go
+++ b/api/v1beta1/common_types.go
@@ -38,16 +38,6 @@ type WatcherCommon struct {
 	// PasswordSelectors - Selectors to identify the ServiceUser password from the Secret
 	PasswordSelectors PasswordSelector `json:"passwordSelectors"`
 
-	// +kubebuilder:validation:Required
-	// MariaDB instance name
-	// Required to use the mariadb-operator instance to create the DB and user
-	DatabaseInstance string `json:"databaseInstance"`
-
-	// +kubebuilder:validation:Optional
-	// +kubebuilder:default=watcher
-	// DatabaseAccount - MariaDBAccount CR name used for watcher DB, defaults to watcher
-	DatabaseAccount string `json:"databaseAccount"`
-
 	// +kubebuilder:validation:Optional
 	// +kubebuilder:default=memcached
 	// MemcachedInstance is the name of the Memcached CR that all watcher service will use.
@@ -75,6 +65,16 @@ type WatcherTemplate struct {
 	// +kubebuilder:default=osp-secret
 	// Secret containing all passwords / keys needed
 	Secret string `json:"secret"`
+
+	// +kubebuilder:validation:Required
+	// MariaDB instance name
+	// Required to use the mariadb-operator instance to create the DB and user
+	DatabaseInstance string `json:"databaseInstance"`
+
+	// +kubebuilder:validation:Optional
+	// +kubebuilder:default=watcher
+	// DatabaseAccount - MariaDBAccount CR name used for watcher DB, defaults to watcher
+	DatabaseAccount string `json:"databaseAccount"`
 }
 
 // PasswordSelector to identify the DB and AdminUser password from the Secret

--- a/config/crd/bases/watcher.openstack.org_watcherapis.yaml
+++ b/config/crd/bases/watcher.openstack.org_watcherapis.yaml
@@ -43,16 +43,6 @@ spec:
                 description: The service specific Container Image URL (will be set
                   to environmental default if empty)
                 type: string
-              databaseAccount:
-                default: watcher
-                description: DatabaseAccount - MariaDBAccount CR name used for watcher
-                  DB, defaults to watcher
-                type: string
-              databaseInstance:
-                description: |-
-                  MariaDB instance name
-                  Required to use the mariadb-operator instance to create the DB and user
-                type: string
               memcachedInstance:
                 default: memcached
                 description: MemcachedInstance is the name of the Memcached CR that
@@ -84,7 +74,6 @@ spec:
                   to register in keystone
                 type: string
             required:
-            - databaseInstance
             - secret
             type: object
           status:

--- a/config/samples/watcher_v1beta1_watcherapi.yaml
+++ b/config/samples/watcher_v1beta1_watcherapi.yaml
@@ -6,5 +6,4 @@ metadata:
     app.kubernetes.io/managed-by: kustomize
   name: watcherapi-sample
 spec:
-  databaseInstance: "openstack"
-  secret: "osp-secret"
+  secret: "watcher"

--- a/controllers/watcher_common.go
+++ b/controllers/watcher_common.go
@@ -36,6 +36,13 @@ var (
 const (
 	// TransportURLSelector is the name of key in the secret created by TransportURL
 	TransportURLSelector = "transport_url"
+	// DatabaseUsername is the name of key in the secret for the user name used to login to the database
+	DatabaseUsername = "database_username"
+	// DatabaseUsername is the name of key in the secret for the password used to login to the database
+	DatabasePassword = "database_password"
+	// DatabaseUsername is the name of key in the secret for the database
+	// hostname
+	DatabaseHostname = "database_hostname"
 )
 
 // GetLogger returns a logger object with a prefix of "controller.name" and additional controller context fields

--- a/tests/functional/watcher_controller_test.go
+++ b/tests/functional/watcher_controller_test.go
@@ -313,6 +313,12 @@ var _ = Describe("Watcher controller", func() {
 			Watcher := GetWatcher(watcherTest.Instance)
 			Expect(Watcher.Status.Hash[watcherv1beta1.DbSyncHash]).ShouldNot(BeNil())
 
+			// assert that the top level secret is created
+			createdSecret := th.GetSecret(watcherTest.Watcher)
+			Expect(createdSecret).ShouldNot(BeNil())
+			Expect(createdSecret.Data["WatcherPassword"]).To(Equal([]byte("password")))
+			Expect(createdSecret.Data["transport_url"]).To(Equal([]byte("rabbit://rabbitmq-secret/fake")))
+
 		})
 
 		It("Should fail to register watcher service to keystone when has not the expected secret", func() {

--- a/tests/kuttl/test-suites/default/watcher-api/03-assert.yaml
+++ b/tests/kuttl/test-suites/default/watcher-api/03-assert.yaml
@@ -5,8 +5,6 @@ metadata:
   - openstack.org/watcherapi
   name: watcherapi-kuttl
 spec:
-  databaseAccount: watcher
-  databaseInstance: openstack
   passwordSelectors:
     service: WatcherPassword
   secret: watcher-kuttl

--- a/tests/kuttl/test-suites/default/watcher-api/03-assert.yaml
+++ b/tests/kuttl/test-suites/default/watcher-api/03-assert.yaml
@@ -9,7 +9,7 @@ spec:
   databaseInstance: openstack
   passwordSelectors:
     service: WatcherPassword
-  secret: watcherapi-secret
+  secret: watcher-kuttl
 status:
   conditions:
   - message: Setup complete
@@ -32,5 +32,5 @@ status:
 apiVersion: v1
 kind: Secret
 metadata:
-  name: watcherapi-kuttl-config-data
+  name: watcher-kuttl
 type: Opaque

--- a/tests/kuttl/test-suites/default/watcher-api/03-deploy-watcher-api.yaml
+++ b/tests/kuttl/test-suites/default/watcher-api/03-deploy-watcher-api.yaml
@@ -3,6 +3,5 @@ kind: WatcherAPI
 metadata:
   name: watcherapi-kuttl
 spec:
-  databaseInstance: openstack
   secret: watcher-kuttl
   memcachedInstance: "memcached"

--- a/tests/kuttl/test-suites/default/watcher-api/03-deploy-watcher-api.yaml
+++ b/tests/kuttl/test-suites/default/watcher-api/03-deploy-watcher-api.yaml
@@ -1,17 +1,8 @@
-apiVersion: v1
-kind: Secret
-metadata:
-  name: watcherapi-secret
-type: Opaque
-stringData:
-  WatcherPassword: password
-  transport_url: rabbitmq-transport-url-watcher-kuttl-watcher-transport
----
 apiVersion: watcher.openstack.org/v1beta1
 kind: WatcherAPI
 metadata:
   name: watcherapi-kuttl
 spec:
   databaseInstance: openstack
-  secret: watcherapi-secret
+  secret: watcher-kuttl
   memcachedInstance: "memcached"

--- a/tests/kuttl/test-suites/default/watcher/01-assert.yaml
+++ b/tests/kuttl/test-suites/default/watcher/01-assert.yaml
@@ -121,6 +121,11 @@ metadata:
   name: rabbitmq-transport-url-watcher-kuttl-watcher-transport
   namespace: watcher-kuttl-default
 ---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: watcher-kuttl
+---
 apiVersion: keystone.openstack.org/v1beta1
 kind: KeystoneService
 metadata:

--- a/tests/kuttl/test-suites/default/watcher/04-assert.yaml
+++ b/tests/kuttl/test-suites/default/watcher/04-assert.yaml
@@ -66,6 +66,11 @@ metadata:
   finalizers:
   - openstack.org/watcher
 ---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: watcher-kuttl
+---
 apiVersion: mariadb.openstack.org/v1beta1
 kind: MariaDBAccount
 metadata:

--- a/tests/kuttl/test-suites/default/watcher/05-errors.yaml
+++ b/tests/kuttl/test-suites/default/watcher/05-errors.yaml
@@ -13,6 +13,11 @@ kind: Secret
 metadata:
   name: rabbitmq-transport-url-watcher-kuttl-watcher-transport
 ---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: watcher-kuttl
+---
 apiVersion: rabbitmq.openstack.org/v1beta1
 kind: TransportURL
 metadata:


### PR DESCRIPTION
Create an internal secret in the watcher controller to pass to the
sub CRs (atm only for WatcherAPI). Initially, this secret contains the
service password and the transport url. Eventually, this secret will be
set as the Secret field in the sub CRs specs, once they are created from
the Watcher controller.

Related: [OSPRH-11483](https://issues.redhat.com//browse/OSPRH-11483)