### PR TITLE
Add webhook validation for empty database and rabbitmq

### DIFF
--- a/api/v1beta1/common_types.go
+++ b/api/v1beta1/common_types.go
@@ -67,7 +67,7 @@ type WatcherTemplate struct {
 	// +kubebuilder:default=rabbitmq
 	// RabbitMQ instance name
 	// Needed to request a transportURL that is created and used in Watcher
-	RabbitMqClusterName string `json:"rabbitMqClusterName"`
+	RabbitMqClusterName *string `json:"rabbitMqClusterName"`
 
 	// +kubebuilder:validation:Optional
 	// +kubebuilder:default=osp-secret
@@ -77,7 +77,7 @@ type WatcherTemplate struct {
 	// +kubebuilder:validation:Required
 	// MariaDB instance name
 	// Required to use the mariadb-operator instance to create the DB and user
-	DatabaseInstance string `json:"databaseInstance"`
+	DatabaseInstance *string `json:"databaseInstance"`
 
 	// +kubebuilder:validation:Optional
 	// +kubebuilder:default=watcher

--- a/api/v1beta1/watcher_webhook.go
+++ b/api/v1beta1/watcher_webhook.go
@@ -17,6 +17,8 @@ limitations under the License.
 package v1beta1
 
 import (
+	"errors"
+
 	"k8s.io/apimachinery/pkg/runtime"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
@@ -64,12 +66,28 @@ var _ webhook.Validator = &Watcher{}
 func (r *Watcher) ValidateCreate() (admission.Warnings, error) {
 	watcherlog.Info("validate create", "name", r.Name)
 
+	if *r.Spec.DatabaseInstance == "" || r.Spec.DatabaseInstance == nil {
+		return nil, errors.New("databaseInstance field should not be empty")
+	}
+
+	if *r.Spec.RabbitMqClusterName == "" || r.Spec.RabbitMqClusterName == nil {
+		return nil, errors.New("rabbitMqClusterName field should not be empty")
+	}
+
 	return nil, nil
 }
 
 // ValidateUpdate implements webhook.Validator so a webhook will be registered for the type
 func (r *Watcher) ValidateUpdate(runtime.Object) (admission.Warnings, error) {
 	watcherlog.Info("validate update", "name", r.Name)
+
+	if *r.Spec.DatabaseInstance == "" || r.Spec.DatabaseInstance == nil {
+		return nil, errors.New("databaseInstance field should not be empty")
+	}
+
+	if *r.Spec.RabbitMqClusterName == "" || r.Spec.RabbitMqClusterName == nil {
+		return nil, errors.New("rabbitMqClusterName field should not be empty")
+	}
 
 	return nil, nil
 }

--- a/api/v1beta1/zz_generated.deepcopy.go
+++ b/api/v1beta1/zz_generated.deepcopy.go
@@ -560,6 +560,16 @@ func (in *WatcherSubCrsTemplate) DeepCopy() *WatcherSubCrsTemplate {
 func (in *WatcherTemplate) DeepCopyInto(out *WatcherTemplate) {
 	*out = *in
 	in.WatcherCommon.DeepCopyInto(&out.WatcherCommon)
+	if in.RabbitMqClusterName != nil {
+		in, out := &in.RabbitMqClusterName, &out.RabbitMqClusterName
+		*out = new(string)
+		**out = **in
+	}
+	if in.DatabaseInstance != nil {
+		in, out := &in.DatabaseInstance, &out.DatabaseInstance
+		*out = new(string)
+		**out = **in
+	}
 	in.APIServiceTemplate.DeepCopyInto(&out.APIServiceTemplate)
 }
 

--- a/controllers/watcher_controller.go
+++ b/controllers/watcher_controller.go
@@ -457,11 +457,11 @@ func (r *WatcherReconciler) ensureDB(
 	// create watcher DB instance
 	//
 	db := mariadbv1.NewDatabaseForAccount(
-		instance.Spec.DatabaseInstance, // mariadb/galera service to target
-		watcher.DatabaseName,           // name used in CREATE DATABASE in mariadb
-		watcher.DatabaseCRName,         // CR name for MariaDBDatabase
-		instance.Spec.DatabaseAccount,  // CR name for MariaDBAccount
-		instance.Namespace,             // namespace
+		*instance.Spec.DatabaseInstance, // mariadb/galera service to target
+		watcher.DatabaseName,            // name used in CREATE DATABASE in mariadb
+		watcher.DatabaseCRName,          // CR name for MariaDBDatabase
+		instance.Spec.DatabaseAccount,   // CR name for MariaDBAccount
+		instance.Namespace,              // namespace
 	)
 
 	// create or patch the DB
@@ -528,7 +528,7 @@ func (r *WatcherReconciler) ensureMQ(
 	}
 
 	op, err := controllerutil.CreateOrUpdate(ctx, r.Client, transportURL, func() error {
-		transportURL.Spec.RabbitmqClusterName = instance.Spec.RabbitMqClusterName
+		transportURL.Spec.RabbitmqClusterName = *instance.Spec.RabbitMqClusterName
 
 		err := controllerutil.SetControllerReference(instance, transportURL, r.Scheme)
 		return err


### PR DESCRIPTION
databaseInstance and rabbitMqClusterName are required fields. If an user specify databaseInstance and rabbitMqClusterName field as empty string. The webhook should fail it saying as there cannot be empty.

This pr adds the validations for the same.

Jira: https://issues.redhat.com/browse/OSPRH-11933

Depends-On: https://github.com/openstack-k8s-operators/ci-framework/pull/2658