### PR TITLE
Update Ruby action

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -24,7 +24,7 @@ jobs:
         with:
           # this fetches all branches. Needed because we need gh-pages branch for deploy to work
           fetch-depth: 0
-      - uses: ruby/setup-ruby@v1.160.0
+      - uses: ruby/setup-ruby@v1
         with:
           ruby-version: '3.2'
 


### PR DESCRIPTION
Build Docs github action is broken with following error[1]
```
Error: The current runner (ubuntu-24.04-x64) was detected as self-hosted because the platform does not match a GitHub-hosted runner image (or that image is deprecated and no longer supported).
```
Using ruby/setup-ruby@v1 fixes the issue.

Similar fix is proposed here also https://github.com/openstack-k8s-operators/data-plane-adoption/pull/777

Link:
[1]. https://github.com/openstack-k8s-operators/watcher-operator/actions/runs/12664082918/job/35291667930