### PR TITLE
Add a github action to sync content from main to fr1 branch

### DIFF
--- a/.github/workflows/build-watcher-operator.yaml
+++ b/.github/workflows/build-watcher-operator.yaml
@@ -3,7 +3,7 @@ name: watcher operator image builder
 on:
   push:
     branches:
-      - '*'
+      - 'main'
 
 env:
   imageregistry: 'quay.io'

--- a/.github/workflows/sync-to-fr1-branch.yaml
+++ b/.github/workflows/sync-to-fr1-branch.yaml
@@ -1,0 +1,24 @@
+name: Mirror to fr1 branch
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  mirror-main-to-fr1:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Push changes to fr1 branch
+        run: |
+          git checkout main
+          git branch -a -v
+          git push origin main:18.0-fr1


### PR DESCRIPTION
In order to align with the resto of operators we need to have a 18.0-fr1 branch. However, we do not want to manually cherry-pick every commit but to get any new commit into the branch until we have a fully functional repo.

This patch is adding a job which will sync content from main to the branch 18.0-fr1 after any merge into the main branch.

We may need to first create the new branch manually.