### PR TITLE
Test opendev watcher master content in CI job

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -2,20 +2,19 @@
 - project:
     name: openstack-k8s-operators/watcher-operator
     default-branch: main
+    templates:
+      - opendev-master-watcher-operator-pipeline
     github-check:
       jobs:
         - noop
         - watcher-operator-doc-preview
-        - openstack-meta-content-provider:
-            vars:
-              cifmw_operator_build_meta_build: false
         - watcher-operator-validation
         - watcher-operator-kuttl
 
 - job:
     name: watcher-operator-base
     parent: podified-multinode-edpm-deployment-crc-2comp
-    dependencies: ["openstack-meta-content-provider"]
+    dependencies: ["openstack-meta-content-provider-master"]
     description: |
       A multinode EDPM Zuul job which has one ansible controller, one
       extracted crc and two computes. It will be used for testing watcher-operator.
@@ -23,6 +22,15 @@
       watcher_repo: "{{ ansible_user_dir }}/src/github.com/openstack-k8s-operators/watcher-operator"
       watcher_hook: "{{ watcher_repo }}/ci/playbooks/deploy_watcher_service.yaml"
       watcher_coo_hook: "{{ watcher_repo }}/ci/playbooks/deploy_cluster_observability_operator.yaml"
+      run_tempest: false
+      # Based on current testing, https://github.com/openstack-k8s-operators/watcher-operator/pull/47#issuecomment-2607474033
+      # We need decision engine and applier CRD to ready to run
+      # whole test suite
+      cifmw_test_operator_tempest_include_list: |
+        watcher_tempest_plugin.tests.api.admin.test_api_discovery.TestApiDiscovery
+      # Donot use openstack services containers from meta content provider master
+      # job.
+      cifmw_update_containers_openstack: false
       # controlplane customization to deploy telemetry service
       cifmw_edpm_prepare_timeout: 60
       cifmw_edpm_prepare_kustomizations:
@@ -65,25 +73,37 @@
     parent: watcher-operator-base
     description: |
       A zuul job to validate the watcher operator and its service deployment.
+      It will deploy podified and EDPM using current-podified antelope content.
+      During watcher deployment, It will fetch master current-podified hash and pull
+      openstack watcher services containers from meta content provider.
+      It will test current-podified control plane EDPM deployment with openstack watcher
+      master content.
+    extra-vars:
+      # Override zuul meta content provider provided content_provider_dlrn_md5_hash
+      # var. As returned dlrn md5 hash comes from master release but job is using
+      # antelope content.
+      content_provider_dlrn_md5_hash: ''
     vars:
-      run_tempest: false
-      # Based on current testing, https://github.com/openstack-k8s-operators/watcher-operator/pull/47#issuecomment-2607474033
-      # We need decision engine and applier CRD to ready to run
-      # whole test suite
-      cifmw_test_operator_tempest_include_list: |
-        watcher_tempest_plugin.tests.api.admin.test_api_discovery.TestApiDiscovery
+      # Donot use openstack services containers from meta content provider master
+      # job.
+      cifmw_update_containers_openstack: false
 
 - job:
     name: watcher-operator-kuttl
+    dependencies: ["openstack-meta-content-provider-master"]
     parent: cifmw-multinode-kuttl-operator-target
     description: |
       A zuul job to run watcher operator kuttl tests.
+      It will pull operator images from meta content provider. There is no
+      change in openstack services container images.
     vars:
       operator_name: watcher-operator
       cifmw_install_yamls_whitelisted_vars: *install_yamls_whitelist
       watcher_repo: "{{ ansible_user_dir }}/src/github.com/openstack-k8s-operators/watcher-operator"
       watcher_hook: "{{ watcher_repo }}/ci/playbooks/deploy_watcher_service.yaml"
       deploy_watcher_service: false
+      # Do not fetch dlrn md5 hash
+      fetch_dlrn_hash: false
       # run the hook to install watcher at the end of the cifmw infra playbook. If we try to run it
       # as a standalone plabyook, it tries to load the cifmw ci_script action
       # plugin from the zuul executor and doesn't find it
@@ -93,6 +113,13 @@
           source: "{{ watcher_hook }}"
           extra_vars:
             watcher_catalog_image: "{{ content_provider_registry_ip }}:5001/openstack-k8s-operators/watcher-operator-index:{{ zuul.patchset }}"
+    extra-vars:
+      # Override zuul meta content provider provided content_provider_dlrn_md5_hash
+      # var. As returned dlrn md5 hash comes from master release but job is using
+      # antelope content.
+      content_provider_dlrn_md5_hash: ''
+      # We also need to override the registry otherwise kuttl test will fail
+      content_provider_os_registry_url: "quay.io/podified-master-centos9"
 
 - job:
     name: watcher-operator-doc-preview
@@ -103,3 +130,49 @@
     vars:
       asciidoc_available: true
       doc_available: false
+
+##########################################################
+#                                                        #
+#               Master Zuul Jobs                         #
+#                                                        #
+##########################################################
+- job:
+    name: openstack-meta-content-provider-master
+    description: |
+      A zuul job building content from OpenDev master release.
+    parent: openstack-meta-content-provider
+    vars:
+      cifmw_operator_build_meta_build: false
+      cifmw_bop_openstack_release: master
+      cifmw_bop_dlrn_baseurl: "https://trunk.rdoproject.org/centos9-master"
+      cifmw_repo_setup_branch: master
+      cifmw_build_containers_registry_namespace: podified-master-centos9
+
+- job:
+    name: watcher-operator-validation-master
+    parent: watcher-operator-base
+    description: |
+      A Zuul job consuming content from openstack-meta-content-provider-master
+      and deploying EDPM with master content.
+    vars:
+      cifmw_repo_setup_branch: master
+      # To consume containers from meta content provider
+      cifmw_update_containers_openstack: true
+      cifmw_update_containers_org: podified-master-centos9
+
+##########################################################
+#                                                        #
+#               Project Template                         #
+#                                                        #
+##########################################################
+
+- project-template:
+    name: opendev-master-watcher-operator-pipeline
+    description: |
+      Project template to run meta content provider and
+      EDPM job with master opendev and github operator
+      content.
+    github-check:
+      jobs:
+        - openstack-meta-content-provider-master
+        - watcher-operator-validation-master

--- a/Makefile
+++ b/Makefile
@@ -375,8 +375,14 @@ update-watcher-csv:
 	fi
 
 CATALOG_IMAGE ?= quay.io/openstack-k8s-operators/watcher-operator-index:latest
+WATCHER_API_IMAGE_URL_DEFAULT ?= quay.io/podified-master-centos9/openstack-watcher-api:current-podified
+WATCHER_DECISION_ENGINE_IMAGE_URL_DEFAULT ?= quay.io/podified-master-centos9/openstack-watcher-decision-engine:current-podified
+WATCHER_APPLIER_IMAGE_URL_DEFAULT ?= quay.io/podified-master-centos9/openstack-watcher-applier:current-podified
 
 .PHONY: watcher
+watcher: export WATCHER_API_IMAGE=${WATCHER_API_IMAGE_URL_DEFAULT}
+watcher: export WATCHER_DECISION_ENGINE_IMAGE=${WATCHER_DECISION_ENGINE_IMAGE_URL_DEFAULT}
+watcher: export WATCHER_APPLIER_IMAGE=${WATCHER_APPLIER_IMAGE_URL_DEFAULT}
 watcher: export CATALOG_IMG=${CATALOG_IMAGE}
 watcher: ## Install watcher operator via olm
 	bash ci/olm.sh
@@ -454,9 +460,9 @@ SKIP_CERT ?=false
 .PHONY: run-with-webhook
 run-with-webhook: export METRICS_PORT?=33080
 run-with-webhook: export HEALTH_PORT?=33081
-run-with-webhook: export WATCHER_API_IMAGE_URL_DEFAULT=quay.io/podified-master-centos9/openstack-watcher-api:current-podified
-run-with-webhook: export WATCHER_DECISION_ENGINE_IMAGE_URL_DEFAULT=quay.io/podified-master-centos9/openstack-watcher-decision-engine:current-podified
-run-with-webhook: export WATCHER_APPLIER_IMAGE_URL_DEFAULT=quay.io/podified-master-centos9/openstack-watcher-applier:current-podified
+run-with-webhook: export WATCHER_API_IMAGE_URL_DEFAULT=${WATCHER_API_IMAGE_URL_DEFAULT}
+run-with-webhook: export WATCHER_DECISION_ENGINE_IMAGE_URL_DEFAULT=${WATCHER_DECISION_ENGINE_IMAGE_URL_DEFAULT}
+run-with-webhook: export WATCHER_APPLIER_IMAGE_URL_DEFAULT=${WATCHER_APPLIER_IMAGE_URL_DEFAULT}
 run-with-webhook: manifests generate fmt vet ## Run a controller from your host.
 	/bin/bash hack/clean_local_webhook.sh
 	/bin/bash hack/run_with_local_webhook.sh

--- a/ci/olm.sh
+++ b/ci/olm.sh
@@ -45,4 +45,12 @@ spec:
   channel: alpha
   source: watcher-operator-index
   sourceNamespace: openstack-operators
+  config:
+    env:
+    - name: WATCHER_API_IMAGE_URL_DEFAULT
+      value: ${WATCHER_API_IMAGE}
+    - name: WATCHER_DECISION_ENGINE_IMAGE_URL_DEFAULT
+      value: ${WATCHER_DECISION_ENGINE_IMAGE}
+    - name: WATCHER_APPLIER_IMAGE_URL_DEFAULT
+      value: ${WATCHER_APPLIER_IMAGE}
 EOF_CAT

--- a/ci/playbooks/deploy_watcher_service.yaml
+++ b/ci/playbooks/deploy_watcher_service.yaml
@@ -8,13 +8,36 @@
     KUBECONFIG: "{{ cifmw_openshift_kubeconfig }}"
     PATH: "{{ cifmw_path }}"
   tasks:
+    - name: Fetch dlrn md5_hash from DLRN repo
+      when: fetch_dlrn_hash | default(true) | bool
+      ansible.builtin.uri:
+        url: "https://{{ watcher_dlrn_server | default('trunk.rdoproject.org') }}/{{ watcher_dlrn_namespace | default('centos9-master') }}/{{ watcher_dlrn_tag | default('current-podified') }}/delorean.repo.md5"
+        return_content: true
+      register: latest_dlrn_tag
+      until: latest_dlrn_tag.status == 200
+      retries: 6
+      delay: 5
+
     - name: Install Watcher Operator
+      vars:
+        _tag: "{{ latest_dlrn_tag.content | default('current-podified') }}"
+        # When there is no Depends-On from opendev, then content_provider_os_registry_url will return null
+        # value to child job. In that case, we need to set default to quay registry.
+        _registry_url: >-
+          {%- if content_provider_os_registry_url is defined and content_provider_os_registry_url == 'null' -%}
+          quay.io/podified-master-centos9
+          {%- else -%}
+          {{ content_provider_os_registry_url | default('quay.io/podified-master-centos9') }}
+          {%- endif -%}
       cifmw.general.ci_script:
         output_dir: "{{ cifmw_basedir }}/artifacts"
         chdir: "{{ ansible_user_dir }}/src/github.com/openstack-k8s-operators/watcher-operator"
         script: make watcher
         extra_args:
           CATALOG_IMAGE: "{{ watcher_catalog_image | default('quay.io/openstack-k8s-operators/watcher-operator-index:latest') }}"
+          WATCHER_API_IMAGE_URL_DEFAULT: "{{ _registry_url }}/openstack-watcher-api:{{ _tag }}"
+          WATCHER_DECISION_ENGINE_IMAGE_URL_DEFAULT: "{{ _registry_url }}/openstack-watcher-decision-engine:{{ _tag }}"
+          WATCHER_APPLIER_IMAGE_URL_DEFAULT: "{{ _registry_url }}/openstack-watcher-applier:{{ _tag }}"
 
     - name: Deploy Watcher service
       when: deploy_watcher_service | default('true') | bool


### PR DESCRIPTION
In order to test opendev watcher master content in CI job, this pr adds following things:

* opendev-master-watcher-operator-pipeline project template which will run meta content provider from master and  then Deploy EDPM job watcher-operator-validation-master from mastter content. It will help to test any opendev watcher patches with master edpm  job.
    
* It changes the existing job watcher-operator-validation (still deploying the antelope content) with update_containers: false to avoid using meta content provider containers. This change will help to test master content with antelope job as
in downstream, we are going to backport lots of watcher master patches downstream. It will help to avoid breakage in advance.
    
* It also updates the existing watcher-operator-validation and watcher-operator-kuttl job to use openstack-meta-content-provider-master as a job dependencies.
    
Depends-On: https://review.opendev.org/c/openstack/watcher/+/938893
Depends-On: https://github.com/openstack-k8s-operators/ci-framework/pull/2675

Test results: https://github.com/openstack-k8s-operators/watcher-operator/pull/39#issuecomment-2618052936 

Related-Jira: https://issues.redhat.com/browse/OSPRH-13660