### PR TITLE
Default watcher container images to master release

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -449,9 +449,9 @@ SKIP_CERT ?=false
 .PHONY: run-with-webhook
 run-with-webhook: export METRICS_PORT?=33080
 run-with-webhook: export HEALTH_PORT?=33081
-run-with-webhook: export WATCHER_API_IMAGE_URL_DEFAULT=quay.io/podified-antelope-centos9/openstack-watcher-api:current-podified
-run-with-webhook: export WATCHER_DECISION_ENGINE_IMAGE_URL_DEFAULT=quay.io/podified-antelope-centos9/openstack-watcher-decision-engine:current-podified
-run-with-webhook: export WATCHER_APPLIER_IMAGE_URL_DEFAULT=quay.io/podified-antelope-centos9/openstack-watcher-applier:current-podified
+run-with-webhook: export WATCHER_API_IMAGE_URL_DEFAULT=quay.io/podified-master-centos9/openstack-watcher-api:current-podified
+run-with-webhook: export WATCHER_DECISION_ENGINE_IMAGE_URL_DEFAULT=quay.io/podified-master-centos9/openstack-watcher-decision-engine:current-podified
+run-with-webhook: export WATCHER_APPLIER_IMAGE_URL_DEFAULT=quay.io/podified-master-centos9/openstack-watcher-applier:current-podified
 run-with-webhook: manifests generate fmt vet ## Run a controller from your host.
 	/bin/bash hack/clean_local_webhook.sh
 	/bin/bash hack/run_with_local_webhook.sh

--- a/api/v1beta1/common_types.go
+++ b/api/v1beta1/common_types.go
@@ -23,9 +23,9 @@ import (
 
 // Container image fall-back defaults
 const (
-	WatcherAPIContainerImage            = "quay.io/podified-antelope-centos9/openstack-watcher-api:current-podified"
-	WatcherDecisionEngineContainerImage = "quay.io/podified-antelope-centos9/openstack-watcher-decision-engine:current-podified"
-	WatcherApplierContainerImage        = "quay.io/podified-antelope-centos9/openstack-watcher-applier:current-podified"
+	WatcherAPIContainerImage            = "quay.io/podified-master-centos9/openstack-watcher-api:current-podified"
+	WatcherDecisionEngineContainerImage = "quay.io/podified-master-centos9/openstack-watcher-decision-engine:current-podified"
+	WatcherApplierContainerImage        = "quay.io/podified-master-centos9/openstack-watcher-applier:current-podified"
 )
 
 // WatcherCommon defines a spec based reusable for all the CRDs

--- a/config/default/manager_default_images.yaml
+++ b/config/default/manager_default_images.yaml
@@ -12,8 +12,8 @@ spec:
       - name: manager
         env:
         - name: WATCHER_API_IMAGE_URL_DEFAULT
-          value: quay.io/podified-antelope-centos9/openstack-watcher-api:current-podified
+          value: quay.io/podified-master-centos9/openstack-watcher-api:current-podified
         - name: WATCHER_DECISION_ENGINE_IMAGE_URL_DEFAULT
-          value: quay.io/podified-antelope-centos9/openstack-watcher-decision-engine:current-podified
+          value: quay.io/podified-master-centos9/openstack-watcher-decision-engine:current-podified
         - name: WATCHER_APPLIER_IMAGE_URL_DEFAULT
-          value: quay.io/podified-antelope-centos9/openstack-watcher-applier:current-podified
+          value: quay.io/podified-master-centos9/openstack-watcher-applier:current-podified

--- a/config/samples/watcher_v1beta1_watcherapi.yaml
+++ b/config/samples/watcher_v1beta1_watcherapi.yaml
@@ -8,7 +8,4 @@ metadata:
 spec:
   secret: "watcher"
   memcachedInstance: "memcached"
-  # jgilaber this field should be removed once we create the WatcherAPI from
-  # the Watcher controller
-  containerImage: "quay.io/podified-antelope-centos9/openstack-watcher-api:current-podified"
   serviceAccount: "watcher-watcher"

--- a/tests/kuttl/test-suites/default/common/deploy-with-defaults.yaml
+++ b/tests/kuttl/test-suites/default/common/deploy-with-defaults.yaml
@@ -5,6 +5,3 @@ metadata:
   namespace: watcher-kuttl-default
 spec:
   databaseInstance: "openstack"
-  apiContainerImageURL: "quay.io/podified-master-centos9/openstack-watcher-api:current-podified"
-  decisionengineContainerImageURL: "quay.io/podified-master-centos9/openstack-watcher-decision-engine:current-podified"
-  applierContainerImageURL: "quay.io/podified-master-centos9/openstack-watcher-applier:current-podified"

--- a/tests/kuttl/test-suites/default/watcher/04-deploy-with-precreated-account.yaml
+++ b/tests/kuttl/test-suites/default/watcher/04-deploy-with-precreated-account.yaml
@@ -6,8 +6,5 @@ metadata:
 spec:
   databaseInstance: "openstack"
   databaseAccount: watcher-precreated
-  apiContainerImageURL: "quay.io/podified-master-centos9/openstack-watcher-api:current-podified"
-  decisionengineContainerImageURL: "quay.io/podified-master-centos9/openstack-watcher-decision-engine:current-podified"
-  applierContainerImageURL: "quay.io/podified-master-centos9/openstack-watcher-applier:current-podified"
   apiServiceTemplate:
     replicas: 2


### PR DESCRIPTION
Currently watcher-operator defaults to antelope release container images. However, in order to integrate in openatck-k8s-operators environments it requires integration with prometheus which will only be supported in master (epoxy) cycle.

This patch is setting master container images as defaults. Once epoxy is release we can move to them if available.

Depends-On: https://github.com/openstack-k8s-operators/ci-framework/pull/2658