### PR TITLE
Rename the watcherapi deployment

### DIFF
--- a/pkg/watcherapi/deployment.go
+++ b/pkg/watcherapi/deployment.go
@@ -1,8 +1,6 @@
 package watcherapi
 
 import (
-	"fmt"
-
 	"github.com/openstack-k8s-operators/lib-common/modules/common/env"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -69,7 +67,7 @@ func Deployment(
 
 	deployment := &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      fmt.Sprintf("%s-api", instance.Name),
+			Name:      instance.Name,
 			Namespace: instance.Namespace,
 			Labels:    labels,
 		},

--- a/tests/functional/watcher_test_data.go
+++ b/tests/functional/watcher_test_data.go
@@ -113,7 +113,7 @@ func GetWatcherTestData(watcherName types.NamespacedName) WatcherTestData {
 		},
 		WatcherAPIDeployment: types.NamespacedName{
 			Namespace: watcherName.Namespace,
-			Name:      "watcher-api-api",
+			Name:      "watcher-api",
 		},
 	}
 }

--- a/tests/kuttl/test-suites/default/watcher/01-assert.yaml
+++ b/tests/kuttl/test-suites/default/watcher/01-assert.yaml
@@ -224,7 +224,7 @@ status:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: watcher-kuttl-api-api
+  name: watcher-kuttl-api
   labels:
     service: watcher-api
 spec:

--- a/tests/kuttl/test-suites/default/watcher/04-assert.yaml
+++ b/tests/kuttl/test-suites/default/watcher/04-assert.yaml
@@ -205,7 +205,7 @@ status:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: watcher-kuttl-api-api
+  name: watcher-kuttl-api
   labels:
     service: watcher-api
 spec:

--- a/tests/kuttl/test-suites/default/watcher/05-errors.yaml
+++ b/tests/kuttl/test-suites/default/watcher/05-errors.yaml
@@ -60,7 +60,7 @@ metadata:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: watcher-kuttl-api-api
+  name: watcher-kuttl-api
 ---
 apiVersion: v1
 kind: Pod


### PR DESCRIPTION
Remove the '-api' suffix from the deployment name, as it usually is
redundant.

Depends-On: https://github.com/openstack-k8s-operators/ci-framework/pull/2658
