### PR TITLE
Add CustomServiceConfig

### DIFF
--- a/api/bases/watcher.openstack.org_watcherapis.yaml
+++ b/api/bases/watcher.openstack.org_watcherapis.yaml
@@ -43,6 +43,12 @@ spec:
                 description: The service specific Container Image URL (will be set
                   to environmental default if empty)
                 type: string
+              customServiceConfig:
+                description: |-
+                  CustomServiceConfig - customize the service config using this parameter to change service defaults,
+                  or overwrite rendered information using raw OpenStack config format. The content gets added to
+                  to /etc/<service>/<service>.conf.d directory as a custom config file.
+                type: string
               memcachedInstance:
                 default: memcached
                 description: MemcachedInstance is the name of the Memcached CR that

--- a/api/bases/watcher.openstack.org_watchers.yaml
+++ b/api/bases/watcher.openstack.org_watchers.yaml
@@ -47,6 +47,12 @@ spec:
                   replicas: 1
                 description: APIServiceTemplate - define the watcher-api service
                 properties:
+                  customServiceConfig:
+                    description: |-
+                      CustomServiceConfig - customize the service config using this parameter to change service defaults,
+                      or overwrite rendered information using raw OpenStack config format. The content gets added to
+                      to /etc/<service>/<service>.conf.d directory as a custom config file.
+                    type: string
                   nodeSelector:
                     additionalProperties:
                       type: string
@@ -166,6 +172,12 @@ spec:
                 type: object
               applierContainerImageURL:
                 description: ApplierContainerImageURL
+                type: string
+              customServiceConfig:
+                description: |-
+                  CustomServiceConfig - customize the service config using this parameter to change service defaults,
+                  or overwrite rendered information using raw OpenStack config format. The content gets added to
+                  to /etc/<service>/<service>.conf.d directory as a custom config file.
                 type: string
               databaseAccount:
                 default: watcher

--- a/api/v1beta1/common_types.go
+++ b/api/v1beta1/common_types.go
@@ -59,6 +59,12 @@ type WatcherCommon struct {
 	NodeSelector *map[string]string `json:"nodeSelector,omitempty"`
 
 	// +kubebuilder:validation:Optional
+	// CustomServiceConfig - customize the service config using this parameter to change service defaults,
+	// or overwrite rendered information using raw OpenStack config format. The content gets added to
+	// to /etc/<service>/<service>.conf.d directory as a custom config file.
+	CustomServiceConfig string `json:"customServiceConfig,omitempty"`
+
+	// +kubebuilder:validation:Optional
 	// +operator-sdk:csv:customresourcedefinitions:type=spec
 	// TLS - Parameters related to the TLS
 	TLS tls.API `json:"tls,omitempty"`
@@ -148,6 +154,12 @@ type WatcherSubCrsTemplate struct {
 	// NodeSelector to target subset of worker nodes running this component. Setting here overrides
 	// any global NodeSelector settings within the Watcher CR.
 	NodeSelector *map[string]string `json:"nodeSelector,omitempty"`
+
+	// +kubebuilder:validation:Optional
+	// CustomServiceConfig - customize the service config using this parameter to change service defaults,
+	// or overwrite rendered information using raw OpenStack config format. The content gets added to
+	// to /etc/<service>/<service>.conf.d directory as a custom config file.
+	CustomServiceConfig string `json:"customServiceConfig,omitempty"`
 }
 
 // MetalLBConfig to configure the MetalLB loadbalancer service

--- a/config/crd/bases/watcher.openstack.org_watcherapis.yaml
+++ b/config/crd/bases/watcher.openstack.org_watcherapis.yaml
@@ -43,6 +43,12 @@ spec:
                 description: The service specific Container Image URL (will be set
                   to environmental default if empty)
                 type: string
+              customServiceConfig:
+                description: |-
+                  CustomServiceConfig - customize the service config using this parameter to change service defaults,
+                  or overwrite rendered information using raw OpenStack config format. The content gets added to
+                  to /etc/<service>/<service>.conf.d directory as a custom config file.
+                type: string
               memcachedInstance:
                 default: memcached
                 description: MemcachedInstance is the name of the Memcached CR that

--- a/config/crd/bases/watcher.openstack.org_watchers.yaml
+++ b/config/crd/bases/watcher.openstack.org_watchers.yaml
@@ -47,6 +47,12 @@ spec:
                   replicas: 1
                 description: APIServiceTemplate - define the watcher-api service
                 properties:
+                  customServiceConfig:
+                    description: |-
+                      CustomServiceConfig - customize the service config using this parameter to change service defaults,
+                      or overwrite rendered information using raw OpenStack config format. The content gets added to
+                      to /etc/<service>/<service>.conf.d directory as a custom config file.
+                    type: string
                   nodeSelector:
                     additionalProperties:
                       type: string
@@ -166,6 +172,12 @@ spec:
                 type: object
               applierContainerImageURL:
                 description: ApplierContainerImageURL
+                type: string
+              customServiceConfig:
+                description: |-
+                  CustomServiceConfig - customize the service config using this parameter to change service defaults,
+                  or overwrite rendered information using raw OpenStack config format. The content gets added to
+                  to /etc/<service>/<service>.conf.d directory as a custom config file.
                 type: string
               databaseAccount:
                 default: watcher

--- a/controllers/watcher_controller.go
+++ b/controllers/watcher_controller.go
@@ -641,7 +641,8 @@ func (r *WatcherReconciler) generateServiceConfigDBSync(
 	}
 	// customData hold any customization for the service.
 	customData := map[string]string{
-		"my.cnf": db.GetDatabaseClientConfig(tlsCfg), //(mschuppert) for now just get the default my.cnf
+		watcher.GlobalCustomConfigFileName: instance.Spec.CustomServiceConfig,
+		"my.cnf":                           db.GetDatabaseClientConfig(tlsCfg), //(mschuppert) for now just get the default my.cnf
 	}
 
 	labels := labels.GetLabels(instance, labels.GetGroupLabel(watcher.ServiceName), map[string]string{})
@@ -733,6 +734,7 @@ func (r *WatcherReconciler) createSubLevelSecret(
 		DatabaseUsername:                        databaseAccount.Spec.UserName,
 		DatabasePassword:                        string(databaseSecret.Data[mariadbv1.DatabasePasswordSelector]),
 		DatabaseHostname:                        db.GetDatabaseHostname(),
+		watcher.GlobalCustomConfigFileName:      instance.Spec.CustomServiceConfig,
 	}
 	secretName := instance.Name
 
@@ -762,11 +764,12 @@ func (r *WatcherReconciler) ensureAPI(
 	watcherAPISpec := watcherv1beta1.WatcherAPISpec{
 		Secret: instance.Name,
 		WatcherCommon: watcherv1beta1.WatcherCommon{
-			ServiceUser:       instance.Spec.ServiceUser,
-			PasswordSelectors: instance.Spec.PasswordSelectors,
-			MemcachedInstance: instance.Spec.MemcachedInstance,
-			NodeSelector:      instance.Spec.APIServiceTemplate.NodeSelector,
-			PreserveJobs:      instance.Spec.PreserveJobs,
+			ServiceUser:         instance.Spec.ServiceUser,
+			PasswordSelectors:   instance.Spec.PasswordSelectors,
+			MemcachedInstance:   instance.Spec.MemcachedInstance,
+			NodeSelector:        instance.Spec.APIServiceTemplate.NodeSelector,
+			PreserveJobs:        instance.Spec.PreserveJobs,
+			CustomServiceConfig: instance.Spec.APIServiceTemplate.CustomServiceConfig,
 		},
 		WatcherSubCrsCommon: watcherv1beta1.WatcherSubCrsCommon{
 			ContainerImage: instance.Spec.APIContainerImageURL,

--- a/controllers/watcherapi_controller.go
+++ b/controllers/watcherapi_controller.go
@@ -164,6 +164,7 @@ func (r *WatcherAPIReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 			instance.Spec.PasswordSelectors.Service,
 			TransportURLSelector,
 			DatabaseAccount,
+			watcher.GlobalCustomConfigFileName,
 		},
 		helper.GetClient(),
 		&instance.Status.Conditions,
@@ -299,7 +300,9 @@ func (r *WatcherAPIReconciler) generateServiceConfigs(
 	}
 	// customData hold any customization for the service.
 	customData := map[string]string{
-		"my.cnf": db.GetDatabaseClientConfig(tlsCfg), //(mschuppert) for now just get the default my.cnf
+		watcher.GlobalCustomConfigFileName:  string(secret.Data[watcher.GlobalCustomConfigFileName]),
+		watcher.ServiceCustomConfigFileName: instance.Spec.CustomServiceConfig,
+		"my.cnf":                            db.GetDatabaseClientConfig(tlsCfg), //(mschuppert) for now just get the default my.cnf
 	}
 
 	databaseUsername := string(secret.Data[DatabaseUsername])

--- a/pkg/watcher/constants.go
+++ b/pkg/watcher/constants.go
@@ -20,8 +20,11 @@ const (
 	// DefaultsConfigFileName - File name with default configuration
 	DefaultsConfigFileName = "00-default.conf"
 
-	// CustomConfigFileName - File name with custom configuration
-	CustomConfigFileName = "01-custom.conf"
+	// GlobalCustomConfigFileName - File name with custom configuration define in Watcher
+	GlobalCustomConfigFileName = "01-global-custom.conf"
+
+	// ServiceCustomConfigFileName - File name with custom configuration define in SubCRs
+	ServiceCustomConfigFileName = "02-service-custom.conf"
 
 	// LogVolume is the default logVolume name used to mount logs
 	LogVolume = "logs"

--- a/templates/watcher/config/watcher-api-config.json
+++ b/templates/watcher/config/watcher-api-config.json
@@ -8,6 +8,20 @@
       "perm": "0600"
     },
     {
+      "source": "/var/lib/config-data/default/01-global-custom.conf",
+      "dest": "/etc/watcher/watcher.conf.d/01-global-custom.conf",
+      "owner": "watcher",
+      "perm": "0600",
+      "optional": true
+    },
+    {
+      "source": "/var/lib/config-data/default/02-service-custom.conf",
+      "dest": "/etc/watcher/watcher.conf.d/02-service-custom.conf",
+      "owner": "watcher",
+      "perm": "0600",
+      "optional": true
+    },
+    {
       "source": "/var/lib/config-data/default/10-watcher-wsgi-main.conf",
       "dest": "/etc/httpd/conf.d/10-watcher-wsgi-main.conf",
       "owner": "root",

--- a/tests/functional/base_test.go
+++ b/tests/functional/base_test.go
@@ -44,9 +44,11 @@ func GetNonDefaultWatcherSpec() map[string]interface{} {
 		"preserveJobs":         true,
 		"databaseInstance":     "fakeopenstack",
 		"serviceUser":          "fakeuser",
+		"customServiceConfig":  "# Global config",
 		"apiServiceTemplate": map[string]interface{}{
-			"replicas":     2,
-			"nodeSelector": map[string]string{"foo": "bar"},
+			"replicas":            2,
+			"nodeSelector":        map[string]string{"foo": "bar"},
+			"customServiceConfig": "# Service config",
 		},
 		"tls": map[string]interface{}{
 			"caBundleSecretName": "combined-ca-bundle",

--- a/tests/functional/watcherapi_controller_test.go
+++ b/tests/functional/watcherapi_controller_test.go
@@ -109,12 +109,13 @@ var _ = Describe("WatcherAPI controller", func() {
 			secret := th.CreateSecret(
 				watcherTest.InternalTopLevelSecretName,
 				map[string][]byte{
-					"WatcherPassword":   []byte("service-password"),
-					"transport_url":     []byte("url"),
-					"database_username": []byte("username"),
-					"database_password": []byte("password"),
-					"database_hostname": []byte("hostname"),
-					"database_account":  []byte("watcher"),
+					"WatcherPassword":       []byte("service-password"),
+					"transport_url":         []byte("url"),
+					"database_username":     []byte("username"),
+					"database_password":     []byte("password"),
+					"database_hostname":     []byte("hostname"),
+					"database_account":      []byte("watcher"),
+					"01-global-custom.conf": []byte(""),
 				},
 			)
 			DeferCleanup(k8sClient.Delete, ctx, secret)
@@ -290,12 +291,13 @@ var _ = Describe("WatcherAPI controller", func() {
 			secret := th.CreateSecret(
 				watcherTest.InternalTopLevelSecretName,
 				map[string][]byte{
-					"WatcherPassword":   []byte("service-password"),
-					"transport_url":     []byte("url"),
-					"database_username": []byte("username"),
-					"database_password": []byte("password"),
-					"database_hostname": []byte("hostname"),
-					"database_account":  []byte("watcher"),
+					"WatcherPassword":       []byte("service-password"),
+					"transport_url":         []byte("url"),
+					"database_username":     []byte("username"),
+					"database_password":     []byte("password"),
+					"database_hostname":     []byte("hostname"),
+					"database_account":      []byte("watcher"),
+					"01-global-custom.conf": []byte(""),
 				},
 			)
 			DeferCleanup(k8sClient.Delete, ctx, secret)
@@ -326,12 +328,13 @@ var _ = Describe("WatcherAPI controller", func() {
 			secret := th.CreateSecret(
 				watcherTest.InternalTopLevelSecretName,
 				map[string][]byte{
-					"WatcherPassword":   []byte("service-password"),
-					"transport_url":     []byte("url"),
-					"database_username": []byte("username"),
-					"database_password": []byte("password"),
-					"database_hostname": []byte("hostname"),
-					"database_account":  []byte("watcher"),
+					"WatcherPassword":       []byte("service-password"),
+					"transport_url":         []byte("url"),
+					"database_username":     []byte("username"),
+					"database_password":     []byte("password"),
+					"database_hostname":     []byte("hostname"),
+					"database_account":      []byte("watcher"),
+					"01-global-custom.conf": []byte(""),
 				},
 			)
 			DeferCleanup(k8sClient.Delete, ctx, secret)
@@ -381,9 +384,10 @@ var _ = Describe("WatcherAPI controller", func() {
 			secret := th.CreateSecret(
 				watcherTest.InternalTopLevelSecretName,
 				map[string][]byte{
-					"WatcherPassword":  []byte("service-password"),
-					"transport_url":    []byte("url"),
-					"database_account": []byte("watcher"),
+					"WatcherPassword":       []byte("service-password"),
+					"transport_url":         []byte("url"),
+					"database_account":      []byte("watcher"),
+					"01-global-custom.conf": []byte(""),
 				},
 			)
 			DeferCleanup(k8sClient.Delete, ctx, secret)

--- a/tests/kuttl/test-suites/default/watcher/04-assert.yaml
+++ b/tests/kuttl/test-suites/default/watcher/04-assert.yaml
@@ -10,10 +10,14 @@ spec:
   databaseInstance: openstack
   passwordSelectors:
     service: WatcherPassword
+  customServiceConfig: |
+    # Global config
   secret: osp-secret
   apiServiceTemplate:
     replicas: 2
     resources: {}
+    customServiceConfig: |
+      # Service config
 status:
   apiServiceReadyCount: 2
   conditions:
@@ -227,3 +231,18 @@ spec:
 status:
   readyReplicas: 2
   replicas: 2
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+namespaced: true
+commands:
+  - script: |
+      set -euxo pipefail
+      oc project watcher-kuttl-default
+      APIPOD=$(oc get pods -n watcher-kuttl-default -l "service=watcher-api" -ocustom-columns=:metadata.name|grep -v ^$|head -1)
+      if [ -n "${APIPOD}" ]; then
+        [ $(echo $(oc rsh -c watcher-api ${APIPOD} cat /etc/watcher/watcher.conf.d/01-global-custom.conf) |grep -c "^# Global config") == 1 ]
+        [ $(echo $(oc rsh -c watcher-api ${APIPOD} cat /etc/watcher/watcher.conf.d/02-service-custom.conf) |grep -c "^# Service config") == 1 ]
+      else
+        exit 1
+      fi

--- a/tests/kuttl/test-suites/default/watcher/04-deploy-with-precreated-account.yaml
+++ b/tests/kuttl/test-suites/default/watcher/04-deploy-with-precreated-account.yaml
@@ -6,7 +6,11 @@ metadata:
 spec:
   databaseInstance: "openstack"
   databaseAccount: watcher-precreated
-  apiServiceTemplate:
-    replicas: 2
   tls:
     caBundleSecretName: "combined-ca-bundle"
+  customServiceConfig: |
+    # Global config
+  apiServiceTemplate:
+    replicas: 2
+    customServiceConfig: |
+      # Service config


### PR DESCRIPTION
This patch adds support for services config customization:
- A top level `customServiceConfig` in Watcher CR is used for configuration snippets that are desired in all the Watcher services.
- A second level `customServiceConfig` in each one of the templates, as APIServiceTemplate, etc.. defines per-service specific config.

Depends-On: https://github.com/openstack-k8s-operators/ci-framework/pull/2658
