### PR TITLE
Deploy telemetry service on controlplane

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -22,10 +22,37 @@
     vars:
       watcher_repo: "{{ ansible_user_dir }}/src/github.com/openstack-k8s-operators/watcher-operator"
       watcher_hook: "{{ watcher_repo }}/ci/playbooks/deploy_watcher_service.yaml"
+      watcher_coo_hook: "{{ watcher_repo }}/ci/playbooks/deploy_cluster_observability_operator.yaml"
+      # controlplane customization to deploy telemetry service
+      cifmw_edpm_prepare_timeout: 60
+      cifmw_edpm_prepare_kustomizations:
+        - apiVersion: kustomize.config.k8s.io/v1beta1
+          kind: Kustomization
+          namespace: openstack
+          patches:
+          - patch: |-
+              apiVersion: core.openstack.org/v1beta1
+              kind: OpenStackControlPlane
+              metadata:
+                name: unused
+              spec:
+                telemetry:
+                  enabled: true
+                  template:
+                    metricStorage:
+                      enabled: true
+                      monitoringStack:
+                        alertingEnabled: false
+            target:
+              kind: OpenStackControlPlane
       cifmw_install_yamls_whitelisted_vars: &install_yamls_whitelist
         - 'WATCHER_REPO'
         - 'WATCHER_BRANCH'
         - 'OUTPUT_DIR'
+      pre_deploy_create_coo_subscription:
+        - name: Deploy cluster-observability-operator
+          type: playbook
+          source: "{{ watcher_coo_hook }}"
       post_deploy:
         - name: Deploy watcher service
           type: playbook

--- a/ci/playbooks/deploy_cluster_observability_operator.yaml
+++ b/ci/playbooks/deploy_cluster_observability_operator.yaml
@@ -1,0 +1,45 @@
+---
+# This hook is used to deploy cluster-observability-operator.
+
+- name: Deploy cluster-observability-operator
+  hosts: "{{ cifmw_target_hook_host | default('localhost') }}"
+  gather_facts: false
+  environment:
+    KUBECONFIG: "{{ cifmw_openshift_kubeconfig }}"
+    PATH: "{{ cifmw_path }}"
+  vars:
+    _namespace: "openshift-operators"
+    _operator_name: "operators.coreos.com/cluster-observability-operator.openshift-operators"
+  tasks:
+    - name: Create the COO subscription
+      ansible.builtin.shell:
+        cmd: |
+          oc create -f - <<EOF
+          apiVersion: operators.coreos.com/v1alpha1
+          kind: Subscription
+          metadata:
+            name: cluster-observability-operator
+            namespace: openshift-operators
+          spec:
+            channel: development
+            installPlanApproval: Automatic
+            name: cluster-observability-operator
+            source: redhat-operators
+            sourceNamespace: openshift-marketplace
+          EOF
+      register: output
+
+      # need to have a wait here, since the csv is not created immediately. There is a slight delay, during which time, the oc wait command would fail, since there's no resource to watch
+    - name: Wait for the required resource to be created
+      ansible.builtin.command:
+        cmd:
+          oc get csv -n {{ _namespace }} -l {{ _operator_name }}
+      delay: 10
+      retries: 20
+      register: output
+      until: output.stdout_lines | length != 0
+
+    - name: Wait for the resources to be available
+      ansible.builtin.command:
+        cmd: |
+          oc wait --timeout=300s --for jsonpath="{.status.phase}"=Succeeded csv -n {{ _namespace }} -l {{ _operator_name }}


### PR DESCRIPTION
In order to test integration with watcher and prometheus datasource, we need to install telemetry on the controlplane.

This pr adds the kustomization for enabling telemetry service.

Related-Jira: https://issues.redhat.com/browse/OSPRH-11948