### PR TITLE
Various fixes for watcher config

### DIFF
--- a/templates/watcher/config/10-watcher-wsgi-main.conf
+++ b/templates/watcher/config/10-watcher-wsgi-main.conf
@@ -7,7 +7,7 @@
   ## Vhost docroot
   DocumentRoot "/var/www/cgi-bin"
 
-  ## Directories, there should at least be a declaration for /var/www/cgi-bin/watcher
+  ## Directories, there should at least be a declaration for /var/www/cgi-bin
 
   <Directory "/var/www/cgi-bin">
     Options -Indexes +FollowSymLinks +MultiViews
@@ -16,9 +16,12 @@
   </Directory>
 
   ## Logging
-  ErrorLog "/var/log/watcher/error.log"
+  ErrorLog /dev/stdout
   ServerSignature Off
-  CustomLog "/var/log/watcher/access.log" combined env=!forwarded
+  CustomLog /dev/stdout combined env=!forwarded
+  CustomLog /dev/stdout proxy env=forwarded
+  ## set watcher log level to debug
+  LogLevel debug
 
 {{- if $vhost.TLS }}
   SetEnvIf X-Forwarded-Proto https HTTPS=1

--- a/templates/watcher/config/10-watcher-wsgi-main.conf
+++ b/templates/watcher/config/10-watcher-wsgi-main.conf
@@ -5,11 +5,11 @@
   ServerName {{ $vhost.ServerName }}
 
   ## Vhost docroot
-  DocumentRoot "/var/www/cgi-bin/watcher"
+  DocumentRoot "/var/www/cgi-bin"
 
   ## Directories, there should at least be a declaration for /var/www/cgi-bin/watcher
 
-  <Directory "/var/www/cgi-bin/watcher">
+  <Directory "/var/www/cgi-bin">
     Options -Indexes +FollowSymLinks +MultiViews
     AllowOverride None
     Require all granted

--- a/templates/watcher/config/httpd.conf
+++ b/templates/watcher/config/httpd.conf
@@ -30,11 +30,11 @@ AccessFileName .htaccess
 
 
         HostnameLookups Off
-        LogLevel debug
         EnableSendfile On
 
         TypesConfig /etc/mime.types
         Include "/etc/httpd/conf.modules.d/*.conf"
+        Include "/etc/httpd/conf.d/*.conf"
 
         LogFormat "%a %l %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-Agent}i\"" combined
         LogFormat "%a %l %u %t \"%r\" %>s %b" common
@@ -42,6 +42,9 @@ AccessFileName .htaccess
         LogFormat "%{User-agent}i" agent
         LogFormat "%{X-Forwarded-For}i %l %u %t \"%r\" %s %b \"%{Referer}i\" \"%{User-agent}i\"" forwarded
 
-        CustomLog "/var/log/watcher/access.log" combined env=!forwarded
-        ErrorLog "/var/log/watcher/error.log"
-        IncludeOptional "/etc/httpd/conf.d/*.conf"
+        ErrorLog /dev/stderr
+        TransferLog /dev/stdout
+        CustomLog /dev/stdout combined env=!forwarded
+        CustomLog /dev/stdout proxy env=!forwarded
+        ## set default apache log level to infor from warning
+        LogLevel info

--- a/templates/watcher/config/ssl.conf
+++ b/templates/watcher/config/ssl.conf
@@ -1,0 +1,21 @@
+<IfModule mod_ssl.c>
+  SSLRandomSeed startup builtin
+  SSLRandomSeed startup file:/dev/urandom 512
+  SSLRandomSeed connect builtin
+  SSLRandomSeed connect file:/dev/urandom 512
+
+  AddType application/x-x509-ca-cert .crt
+  AddType application/x-pkcs7-crl    .crl
+
+  SSLPassPhraseDialog builtin
+  SSLSessionCache "shmcb:/var/cache/mod_ssl/scache(512000)"
+  SSLSessionCacheTimeout 300
+  Mutex default
+  SSLCryptoDevice builtin
+  SSLHonorCipherOrder On
+  SSLUseStapling Off
+  SSLStaplingCache "shmcb:/run/httpd/ssl_stapling(32768)"
+  SSLCipherSuite HIGH:MEDIUM:!aNULL:!MD5:!RC4:!3DES
+  SSLProtocol all -SSLv2 -SSLv3 -TLSv1
+  SSLOptions StdEnvVars
+</IfModule>

--- a/templates/watcher/config/watcher-api-config.json
+++ b/templates/watcher/config/watcher-api-config.json
@@ -2,6 +2,12 @@
   "command": "/usr/sbin/httpd -DFOREGROUND",
   "config_files": [
     {
+      "source": "/var/lib/config-data/default/watcher-blank.conf",
+      "dest": "/etc/watcher/watcher.conf",
+      "owner": "watcher",
+      "perm": "0600"
+    },
+    {
       "source": "/var/lib/config-data/default/00-default.conf",
       "dest": "/etc/watcher/watcher.conf.d/00-default.conf",
       "owner": "watcher",

--- a/templates/watcher/config/watcher-api-config.json
+++ b/templates/watcher/config/watcher-api-config.json
@@ -40,6 +40,12 @@
       "owner": "root",
       "perm": "0640",
       "optional": true
+    },
+	{
+      "source": "/var/lib/config-data/default/ssl.conf",
+      "dest": "/etc/httpd/conf.d/ssl.conf",
+      "owner": "root",
+      "perm": "0640"
     }
   ],
   "permissions": [


### PR DESCRIPTION
Introduce several fixes for watcher config:

- **Remove default watcher conf file from rpm**
- **Add ssl.conf file to watcher config**
- **Direct all apache logs to stdout**
