### PR TITLE
Adds config and deploys StatefulSet for WatcherDecisionEngine

### DIFF
--- a/api/bases/watcher.openstack.org_watcherdecisionengines.yaml
+++ b/api/bases/watcher.openstack.org_watcherdecisionengines.yaml
@@ -255,6 +255,10 @@ spec:
                   the openstack-operator in the top-level CR (e.g. the ContainerImage)
                 format: int64
                 type: integer
+              readyCount:
+                description: ReadyCount of WatcherDecisionEngine instances
+                format: int32
+                type: integer
             type: object
         type: object
     served: true

--- a/api/v1beta1/watcherdecisionengine_types.go
+++ b/api/v1beta1/watcherdecisionengine_types.go
@@ -55,6 +55,10 @@ type WatcherDecisionEngineStatus struct {
 	// then the controller has not processed the latest changes injected by
 	// the openstack-operator in the top-level CR (e.g. the ContainerImage)
 	ObservedGeneration int64 `json:"observedGeneration,omitempty"`
+
+	// ReadyCount of WatcherDecisionEngine instances
+	ReadyCount int32 `json:"readyCount,omitempty"`
+
 	// Map of hashes to track e.g. job status
 	Hash map[string]string `json:"hash,omitempty"`
 }

--- a/config/crd/bases/watcher.openstack.org_watcherdecisionengines.yaml
+++ b/config/crd/bases/watcher.openstack.org_watcherdecisionengines.yaml
@@ -255,6 +255,10 @@ spec:
                   the openstack-operator in the top-level CR (e.g. the ContainerImage)
                 format: int64
                 type: integer
+              readyCount:
+                description: ReadyCount of WatcherDecisionEngine instances
+                format: int32
+                type: integer
             type: object
         type: object
     served: true

--- a/config/samples/watcher_v1beta1_watcherdecisionengine.yaml
+++ b/config/samples/watcher_v1beta1_watcherdecisionengine.yaml
@@ -9,4 +9,6 @@ metadata:
     app.kubernetes.io/created-by: watcher-operator
   name: watcherdecisionengine-sample
 spec:
-  # TODO(user): Add fields here
+  secret: "watcher"
+  memcachedInstance: "memcached"
+  serviceAccount: "watcher-watcher"

--- a/controllers/watcher_common.go
+++ b/controllers/watcher_common.go
@@ -66,6 +66,9 @@ const (
 	// WatcherApplierLabelPrefix - a unique, service binary specific prefix for the
 	// labels the WatcherApplier controller uses on children objects
 	WatcherApplierLabelPrefix = "watcher-applier"
+	// WatcherDecisionEngineLabelPrefix - a unique, service binary specific prefix
+	// for the labels the WatcherDecisionEngine controller uses on child objects
+	WatcherDecisionEngineLabelPrefix = "watcher-decision-engine"
 )
 
 // GetLogger returns a logger object with a prefix of "controller.name" and additional controller context fields

--- a/pkg/watcherdecisionengine/statefulset.go
+++ b/pkg/watcherdecisionengine/statefulset.go
@@ -1,0 +1,182 @@
+package watcherdecisionengine
+
+import (
+	"github.com/openstack-k8s-operators/lib-common/modules/common"
+	"github.com/openstack-k8s-operators/lib-common/modules/common/affinity"
+	"github.com/openstack-k8s-operators/lib-common/modules/common/env"
+	watcherv1beta1 "github.com/openstack-k8s-operators/watcher-operator/api/v1beta1"
+	"github.com/openstack-k8s-operators/watcher-operator/pkg/watcher"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
+	"path/filepath"
+)
+
+const (
+	// KollaServiceCommand -
+	KollaServiceCommand = "/usr/local/bin/kolla_start"
+
+	// ComponentName -
+	ComponentName = watcher.ServiceName + "-decision-engine"
+)
+
+func StatefulSet(
+	instance *watcherv1beta1.WatcherDecisionEngine,
+	configHash string,
+	prometheusCaCertSecret map[string]string,
+	labels map[string]string,
+) *appsv1.StatefulSet {
+
+	// This allows the pod to start up slowly. The pod will only be killed
+	// if it does not succeed a probe in 60 seconds.
+	startupProbe := &corev1.Probe{
+		FailureThreshold: 6,
+		PeriodSeconds:    10,
+	}
+	// After the first successful startupProbe, livenessProbe takes over
+	livenessProbe := &corev1.Probe{
+		// TODO might need tuning
+		TimeoutSeconds: 30,
+		PeriodSeconds:  30,
+	}
+	readinessProbe := &corev1.Probe{
+		// TODO might need tuning
+		TimeoutSeconds: 30,
+		PeriodSeconds:  30,
+	}
+
+	envVars := map[string]env.Setter{}
+	envVars["KOLLA_CONFIG_STRATEGY"] = env.SetValue("COPY_ALWAYS")
+	envVars["CONFIG_HASH"] = env.SetValue(configHash)
+	args := []string{"-c", KollaServiceCommand}
+
+	startupProbe.Exec = &corev1.ExecAction{
+		Command: []string{
+			"/usr/bin/pgrep", "-f", "-r", "DRST", ComponentName,
+		},
+	}
+
+	livenessProbe.Exec = &corev1.ExecAction{
+		Command: []string{
+			"/usr/bin/pgrep", "-f", "-r", "DRST", ComponentName,
+		},
+	}
+
+	readinessProbe.Exec = &corev1.ExecAction{
+		Command: []string{
+			"/usr/bin/pgrep", "-f", "-r", "DRST", ComponentName,
+		},
+	}
+	var config0644AccessMode int32 = 0644
+	volumes := append(watcher.GetLogVolume(),
+		corev1.Volume{
+			Name: "config-data-custom",
+			VolumeSource: corev1.VolumeSource{
+				Secret: &corev1.SecretVolumeSource{
+					DefaultMode: &config0644AccessMode,
+					SecretName:  instance.Name + "-config-data",
+				},
+			},
+		},
+	)
+
+	volumeMounts := []corev1.VolumeMount{
+		watcher.GetKollaConfigVolumeMount(ComponentName),
+	}
+	volumeMounts = append(volumeMounts, watcher.GetLogVolumeMount()...)
+
+	// Create mount for bundle CA if defined in TLS.CaBundleSecretName
+	if instance.Spec.TLS.CaBundleSecretName != "" {
+		volumes = append(volumes, instance.Spec.TLS.CreateVolume())
+		volumeMounts = append(volumeMounts, instance.Spec.TLS.CreateVolumeMounts(nil)...)
+	}
+
+	if len(prometheusCaCertSecret) != 0 {
+		volumes = append(volumes,
+			corev1.Volume{
+				Name: "custom-prometheus-ca",
+				VolumeSource: corev1.VolumeSource{
+					Secret: &corev1.SecretVolumeSource{
+						SecretName: prometheusCaCertSecret["casecret_name"],
+					},
+				},
+			},
+		)
+		volumeMounts = append(volumeMounts,
+			corev1.VolumeMount{
+				Name:      "custom-prometheus-ca",
+				MountPath: filepath.Join(watcher.PrometheusCaCertFolderPath, prometheusCaCertSecret["casecret_key"]),
+				SubPath:   prometheusCaCertSecret["casecret_key"],
+				ReadOnly:  true,
+			},
+		)
+	}
+
+	statefulset := &appsv1.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      instance.Name,
+			Namespace: instance.Namespace,
+			Labels:    labels,
+		},
+		Spec: appsv1.StatefulSetSpec{
+			Selector: &metav1.LabelSelector{
+				MatchLabels: labels,
+			},
+			Replicas: instance.Spec.Replicas,
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: labels,
+				},
+				Spec: corev1.PodSpec{
+					ServiceAccountName: instance.Spec.ServiceAccount,
+					Containers: []corev1.Container{
+						{
+							Name: ComponentName,
+							Command: []string{
+								"/bin/bash",
+							},
+							Args:  args,
+							Image: instance.Spec.ContainerImage,
+							SecurityContext: &corev1.SecurityContext{
+								RunAsUser: ptr.To(watcher.WatcherUserID),
+							},
+							Env: env.MergeEnvs([]corev1.EnvVar{}, envVars),
+							VolumeMounts: append(watcher.GetVolumeMounts(
+								[]string{}),
+								volumeMounts...,
+							),
+							Resources:      instance.Spec.Resources,
+							StartupProbe:   startupProbe,
+							ReadinessProbe: readinessProbe,
+							LivenessProbe:  livenessProbe,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	// If possible two pods of the same service should not
+	// run on the same worker node. If this is not possible
+	// the get still created on the same worker node.
+	statefulset.Spec.Template.Spec.Affinity = affinity.DistributePods(
+		common.AppSelector,
+		[]string{
+			watcher.ServiceName,
+		},
+		corev1.LabelHostname,
+	)
+
+	statefulset.Spec.Template.Spec.Volumes = append(watcher.GetVolumes(
+		instance.Name,
+		[]string{}),
+		volumes...)
+
+	if instance.Spec.NodeSelector != nil {
+		statefulset.Spec.Template.Spec.NodeSelector = *instance.Spec.NodeSelector
+	}
+
+	return statefulset
+
+}

--- a/templates/watcher/config/watcher-decision-engine-config.json
+++ b/templates/watcher/config/watcher-decision-engine-config.json
@@ -1,0 +1,32 @@
+{
+    "command": "/usr/bin/watcher-decision-engine --config-dir /etc/watcher/watcher.conf.d",
+    "config_files": [
+      {
+        "source": "/var/lib/config-data/default/00-default.conf",
+        "dest": "/etc/watcher/watcher.conf.d/00-default.conf",
+        "owner": "watcher",
+        "perm": "0600"
+      },
+      {
+        "source": "/var/lib/config-data/default/01-global-custom.conf",
+        "dest": "/etc/watcher/watcher.conf.d/01-global-custom.conf",
+        "owner": "watcher",
+        "perm": "0600",
+        "optional": true
+      },
+      {
+        "source": "/var/lib/config-data/default/02-service-custom.conf",
+        "dest": "/etc/watcher/watcher.conf.d/02-service-custom.conf",
+        "owner": "watcher",
+        "perm": "0600",
+        "optional": true
+      }
+    ],
+    "permissions": [
+        {
+          "path": "/var/log/watcher",
+          "owner": "watcher:watcher",
+          "recurse": true
+        }
+    ]
+}

--- a/templates/watcherdecisionengine
+++ b/templates/watcherdecisionengine
@@ -1,0 +1,1 @@
+watcher

--- a/tests/functional/sample_test.go
+++ b/tests/functional/sample_test.go
@@ -62,6 +62,13 @@ func CreateWatcherApplierFromSample(sampleFileName string, name types.Namespaced
 	return types.NamespacedName{Name: instance.GetName(), Namespace: instance.GetNamespace()}
 }
 
+func CreateWatcherDecisionEngineFromSample(sampleFileName string, name types.NamespacedName) types.NamespacedName {
+	raw := ReadSample(sampleFileName)
+	instance := CreateWatcherDecisionEngine(name, raw["spec"].(map[string]interface{}))
+	DeferCleanup(th.DeleteInstance, instance)
+	return types.NamespacedName{Name: instance.GetName(), Namespace: instance.GetNamespace()}
+}
+
 // This is a set of test for our samples. It only validates that the sample
 // file has all the required field with proper types. But it does not
 // validate that using a sample file will result in a working deployment.
@@ -90,4 +97,12 @@ var _ = Describe("Samples", func() {
 			GetWatcherApplier(name)
 		})
 	})
+
+	When("watcher_v1beta1_watcherdecisionengine.yaml sample is applied", func() {
+		It("WatcherDecisionEngine is created", func() {
+			name := CreateWatcherDecisionEngineFromSample("watcher_v1beta1_watcherdecisionengine.yaml", watcherTest.WatcherDecisionEngine)
+			GetWatcherDecisionEngine(name)
+		})
+	})
+
 })

--- a/tests/functional/watcher_test_data.go
+++ b/tests/functional/watcher_test_data.go
@@ -30,32 +30,33 @@ type APIType string
 // WatcherTestData is the data structure used to provide input data to envTest
 type WatcherTestData struct {
 	//DatabaseHostname             string
-	DatabaseInstance             string
-	RabbitMqClusterName          string
-	Instance                     types.NamespacedName
-	Watcher                      types.NamespacedName
-	WatcherDatabaseName          types.NamespacedName
-	WatcherDatabaseAccount       types.NamespacedName
-	WatcherDatabaseAccountSecret types.NamespacedName
-	InternalTopLevelSecretName   types.NamespacedName
-	PrometheusSecretName         types.NamespacedName
-	WatcherTransportURL          types.NamespacedName
-	KeystoneServiceName          types.NamespacedName
-	WatcherAPI                   types.NamespacedName
-	MemcachedNamespace           types.NamespacedName
-	ServiceAccountName           types.NamespacedName
-	RoleName                     types.NamespacedName
-	RoleBindingName              types.NamespacedName
-	WatcherDBSync                types.NamespacedName
-	WatcherAPIStatefulSet        types.NamespacedName
-	WatcherDecisionEngine        types.NamespacedName
-	WatcherPublicServiceName     types.NamespacedName
-	WatcherInternalServiceName   types.NamespacedName
-	WatcherRouteName             types.NamespacedName
-	WatcherInternalRouteName     types.NamespacedName
-	WatcherKeystoneEndpointName  types.NamespacedName
-	WatcherApplier               types.NamespacedName
-	WatcherApplierStatefulSet    types.NamespacedName
+	DatabaseInstance                 string
+	RabbitMqClusterName              string
+	Instance                         types.NamespacedName
+	Watcher                          types.NamespacedName
+	WatcherDatabaseName              types.NamespacedName
+	WatcherDatabaseAccount           types.NamespacedName
+	WatcherDatabaseAccountSecret     types.NamespacedName
+	InternalTopLevelSecretName       types.NamespacedName
+	PrometheusSecretName             types.NamespacedName
+	WatcherTransportURL              types.NamespacedName
+	KeystoneServiceName              types.NamespacedName
+	WatcherAPI                       types.NamespacedName
+	MemcachedNamespace               types.NamespacedName
+	ServiceAccountName               types.NamespacedName
+	RoleName                         types.NamespacedName
+	RoleBindingName                  types.NamespacedName
+	WatcherDBSync                    types.NamespacedName
+	WatcherAPIStatefulSet            types.NamespacedName
+	WatcherDecisionEngine            types.NamespacedName
+	WatcherDecisionEngineStatefulSet types.NamespacedName
+	WatcherPublicServiceName         types.NamespacedName
+	WatcherInternalServiceName       types.NamespacedName
+	WatcherRouteName                 types.NamespacedName
+	WatcherInternalRouteName         types.NamespacedName
+	WatcherKeystoneEndpointName      types.NamespacedName
+	WatcherApplier                   types.NamespacedName
+	WatcherApplierStatefulSet        types.NamespacedName
 }
 
 // GetWatcherTestData is a function that initialize the WatcherTestData
@@ -108,6 +109,11 @@ func GetWatcherTestData(watcherName types.NamespacedName) WatcherTestData {
 			Namespace: watcherName.Namespace,
 			Name:      "watcher-decision-engine",
 		},
+		WatcherDecisionEngineStatefulSet: types.NamespacedName{
+			Namespace: watcherName.Namespace,
+			Name:      "watcher-decision-engine",
+		},
+
 		MemcachedNamespace: types.NamespacedName{
 			Namespace: watcherName.Namespace,
 			Name:      "memcached",

--- a/tests/functional/watcherapplier_controller_test.go
+++ b/tests/functional/watcherapplier_controller_test.go
@@ -123,7 +123,7 @@ var _ = Describe("WatcherApplier controller", func() {
 			DeferCleanup(
 				mariadb.DeleteDBService,
 				mariadb.CreateDBService(
-					watcherTest.WatcherAPI.Namespace,
+					watcherTest.WatcherApplier.Namespace,
 					"openstack",
 					corev1.ServiceSpec{
 						Ports: []corev1.ServicePort{{Port: 3306}},
@@ -137,7 +137,7 @@ var _ = Describe("WatcherApplier controller", func() {
 				},
 			)
 			mariadb.CreateMariaDBDatabase(
-				watcherTest.WatcherAPI.Namespace,
+				watcherTest.WatcherApplier.Namespace,
 				"watcher",
 				mariadbv1.MariaDBDatabaseSpec{
 					Name: "watcher",
@@ -145,7 +145,7 @@ var _ = Describe("WatcherApplier controller", func() {
 			)
 			mariadb.SimulateMariaDBAccountCompleted(watcherTest.WatcherDatabaseAccount)
 			mariadb.SimulateMariaDBDatabaseCompleted(watcherTest.WatcherDatabaseName)
-			DeferCleanup(keystone.DeleteKeystoneAPI, keystone.CreateKeystoneAPI(watcherTest.WatcherAPI.Namespace))
+			DeferCleanup(keystone.DeleteKeystoneAPI, keystone.CreateKeystoneAPI(watcherTest.WatcherApplier.Namespace))
 			memcachedSpec := memcachedv1.MemcachedSpec{
 				MemcachedSpecCore: memcachedv1.MemcachedSpecCore{
 					Replicas: ptr.To(int32(1)),

--- a/tests/kuttl/test-suites/default/common/cleanup-errors.yaml
+++ b/tests/kuttl/test-suites/default/common/cleanup-errors.yaml
@@ -109,7 +109,7 @@ kind: WatcherDecisionEngine
 metadata:
   finalizers:
   - openstack.org/watcherdecisionengine
-  name: watcherdecisionengine-kuttl
+  name: watcher-decision-engine-kuttl
 ---
 apiVersion: v1
 kind: Secret

--- a/tests/kuttl/test-suites/default/watcher-decision-engine/01-cleanup-watcherdecisionengine.yaml
+++ b/tests/kuttl/test-suites/default/watcher-decision-engine/01-cleanup-watcherdecisionengine.yaml
@@ -3,4 +3,4 @@ kind: TestStep
 delete:
 - apiVersion: watcher.openstack.org/v1beta1
   kind: WatcherDecisionEngine
-  name: watcherdecisionengine-kuttl
+  name: watcher-decision-engine-kuttl

--- a/tests/kuttl/test-suites/default/watcher-decision-engine/03-assert-default.yaml
+++ b/tests/kuttl/test-suites/default/watcher-decision-engine/03-assert-default.yaml
@@ -3,22 +3,27 @@ kind: WatcherDecisionEngine
 metadata:
   finalizers:
   - openstack.org/watcherdecisionengine
-  name: watcherdecisionengine-kuttl
+  name: watcher-decision-engine-kuttl
 spec:
   passwordSelectors:
     service: WatcherPassword
-  secret: osp-secret
+  secret: watcher-kuttl
+  containerImage: quay.io/podified-master-centos9/openstack-watcher-decision-engine:current-podified
   memcachedInstance: memcached
   preserveJobs: false
   serviceUser: watcher
   replicas: 1
-  containerImage: ""
+  serviceAccount: watcher-watcher-kuttl
 status:
   conditions:
   - message: Setup complete
     reason: Ready
     status: "True"
     type: Ready
+  - message: Deployment completed
+    reason: Ready
+    status: "True"
+    type: DeploymentReady
   - message: Input data complete
     reason: Ready
     status: "True"
@@ -31,3 +36,33 @@ status:
     reason: Ready
     status: "True"
     type: ServiceConfigReady
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: watcher-decision-engine-kuttl
+  labels:
+    service: watcher-decision-engine
+spec:
+  replicas: 1
+  template:
+    spec:
+      containers:
+      - name: watcher-decision-engine
+        image: quay.io/podified-master-centos9/openstack-watcher-decision-engine:current-podified
+status:
+  readyReplicas: 1
+  replicas: 1
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: watcher-decision-engine-kuttl-0
+  labels:
+    service: watcher-decision-engine
+spec:
+  containers:
+  - name: watcher-decision-engine
+    image: quay.io/podified-master-centos9/openstack-watcher-decision-engine:current-podified
+status:
+  phase: Running

--- a/tests/kuttl/test-suites/default/watcher-decision-engine/03-deploy-decision-engine.yaml
+++ b/tests/kuttl/test-suites/default/watcher-decision-engine/03-deploy-decision-engine.yaml
@@ -1,9 +1,22 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: metric-storage-prometheus-config
+  namespace: watcher-kuttl-default
+stringData:
+  host: metric-storage-prometheus.watcher-kuttl-default.svc
+  port: "9090"
+  ca_secret: "combined-ca-bundle"
+  ca_key: "internal-ca-bundle.pem"
+---
 apiVersion: watcher.openstack.org/v1beta1
 kind: WatcherDecisionEngine
 metadata:
-  name: watcherdecisionengine-kuttl
+  name: watcher-decision-engine-kuttl
   namespace: watcher-kuttl-default
 spec:
-  secret: osp-secret
+  secret: watcher-kuttl
   tls:
     caBundleSecretName: "combined-ca-bundle"
+  containerImage: "quay.io/podified-master-centos9/openstack-watcher-decision-engine:current-podified"
+  serviceAccount: "watcher-watcher-kuttl"


### PR DESCRIPTION
Adds config and deploys StatefulSet for WatcherDecisionEngine

This follows on from [1] to add missing configuration collection
and creation of a StatefulSet for the DecisionEngine.

[1] https://github.com/openstack-k8s-operators/watcher-operator/pull/44

Depends-On: https://github.com/openstack-k8s-operators/install_yamls/pull/1011
