### PR TITLE
Switch datasource to prometheus

### DIFF
--- a/templates/watcher/config/00-default.conf
+++ b/templates/watcher/config/00-default.conf
@@ -54,7 +54,7 @@ cafile = {{ .CaFilePath }}
 lock_path = /var/lib/watcher/tmp
 
 [watcher_datasources]
-datasources = ceilometer
+datasources = prometheus
 
 {{ if (index . "MemcachedServers") }}
 [cache]


### PR DESCRIPTION
The new datasource is merged in the master branch of watcher repo [1] and ceilometer has been removed [2], so we need to switch to the prometheus datasource:

[1] https://review.opendev.org/c/openstack/watcher/+/934423
[2] https://review.opendev.org/c/openstack/watcher/+/937625