### PR TITLE
Introduce some changes to prepare for TLS support

### DIFF
--- a/controllers/watcher_common.go
+++ b/controllers/watcher_common.go
@@ -16,6 +16,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	memcachedv1 "github.com/openstack-k8s-operators/infra-operator/apis/memcached/v1beta1"
+	"github.com/openstack-k8s-operators/lib-common/modules/common"
 	"github.com/openstack-k8s-operators/lib-common/modules/common/condition"
 	"github.com/openstack-k8s-operators/lib-common/modules/common/env"
 	"github.com/openstack-k8s-operators/lib-common/modules/common/helper"
@@ -24,21 +25,34 @@ import (
 )
 
 const (
-	passwordSecretField   = ".spec.secret"
-	prometheusSecretField = ".spec.prometheusSecret"
+	passwordSecretField     = ".spec.secret"
+	prometheusSecretField   = ".spec.prometheusSecret"
+	caBundleSecretNameField = ".spec.tls.caBundleSecretName"
+	tlsAPIInternalField     = ".spec.tls.api.internal.secretName"
+	tlsAPIPublicField       = ".spec.tls.api.public.secretName"
 )
 
 var (
 	apiWatchFields = []string{
 		passwordSecretField,
 		prometheusSecretField,
+		tlsAPIInternalField,
+		tlsAPIPublicField,
+		caBundleSecretNameField,
 	}
 	applierWatchFields = []string{
 		passwordSecretField,
+		prometheusSecretField,
+		caBundleSecretNameField,
 	}
 	watcherWatchFields = []string{
 		passwordSecretField,
 		prometheusSecretField,
+	}
+	decisionEngineWatchFields = []string{
+		passwordSecretField,
+		prometheusSecretField,
+		caBundleSecretNameField,
 	}
 )
 
@@ -305,4 +319,10 @@ func ensureMemcached(
 	conditionUpdater.MarkTrue(condition.MemcachedReadyCondition, condition.MemcachedReadyMessage)
 
 	return memcached, err
+}
+
+func getAPIServiceLabels() map[string]string {
+	return map[string]string{
+		common.AppSelector: WatcherAPILabelPrefix,
+	}
 }

--- a/controllers/watcherapplier_controller.go
+++ b/controllers/watcherapplier_controller.go
@@ -399,6 +399,29 @@ func (r *WatcherApplierReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	}); err != nil {
 		return err
 	}
+	// index prometheusSecretField
+	if err := mgr.GetFieldIndexer().IndexField(context.Background(), &watcherv1beta1.WatcherApplier{}, prometheusSecretField, func(rawObj client.Object) []string {
+		// Extract the secret name from the spec, if one is provided
+		cr := rawObj.(*watcherv1beta1.WatcherApplier)
+		if cr.Spec.PrometheusSecret == "" {
+			return nil
+		}
+		return []string{cr.Spec.PrometheusSecret}
+	}); err != nil {
+		return err
+	}
+	// index caBundleSecretNameField
+	if err := mgr.GetFieldIndexer().IndexField(context.Background(), &watcherv1beta1.WatcherApplier{}, caBundleSecretNameField, func(rawObj client.Object) []string {
+		// Extract the secret name from the spec, if one is provided
+		cr := rawObj.(*watcherv1beta1.WatcherApplier)
+
+		if cr.Spec.TLS.CaBundleSecretName == "" {
+			return nil
+		}
+		return []string{cr.Spec.TLS.CaBundleSecretName}
+	}); err != nil {
+		return err
+	}
 
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&watcherv1beta1.WatcherApplier{}).

--- a/templates/watcherapi/config/watcher-api-config.json
+++ b/templates/watcherapi/config/watcher-api-config.json
@@ -41,11 +41,27 @@
       "perm": "0644",
       "optional": true
     },
-	{
+    {
       "source": "/var/lib/config-data/default/ssl.conf",
       "dest": "/etc/httpd/conf.d/ssl.conf",
       "owner": "apache",
       "perm": "0444"
+    },
+    {
+      "source": "/var/lib/config-data/tls/certs/*",
+      "dest": "/etc/pki/tls/certs/",
+      "owner": "watcher",
+      "perm": "0640",
+      "optional": true,
+      "merge": true
+    },
+    {
+      "source": "/var/lib/config-data/tls/private/*",
+      "dest": "/etc/pki/tls/private/",
+      "owner": "watcher",
+      "perm": "0600",
+      "optional": true,
+      "merge": true
     }
   ],
   "permissions": [

--- a/tests/functional/base_test.go
+++ b/tests/functional/base_test.go
@@ -79,6 +79,36 @@ func GetDefaultWatcherAPISpec() map[string]interface{} {
 	}
 }
 
+func GetTLSWatcherAPISpec() map[string]interface{} {
+	return map[string]interface{}{
+		"databaseInstance": "openstack",
+		"secret":           SecretName,
+		"containerImage":   "test://watcher",
+		"tls": map[string]interface{}{
+			"caBundleSecretName": "combined-ca-bundle",
+			"api": map[string]interface{}{
+				"internal": map[string]string{
+					"secretName": "cert-watcher-internal-svc",
+				},
+				"public": map[string]string{
+					"secretName": "cert-watcher-public-svc",
+				},
+			},
+		},
+	}
+
+}
+func GetTLSCaWatcherAPISpec() map[string]interface{} {
+	return map[string]interface{}{
+		"databaseInstance": "openstack",
+		"secret":           SecretName,
+		"containerImage":   "test://watcher",
+		"tls": map[string]interface{}{
+			"caBundleSecretName": "combined-ca-bundle",
+		},
+	}
+}
+
 func GetDefaultWatcherApplierSpec() map[string]interface{} {
 	return map[string]interface{}{
 		"databaseInstance":  "openstack",

--- a/tests/functional/watcher_controller_test.go
+++ b/tests/functional/watcher_controller_test.go
@@ -692,6 +692,13 @@ var _ = Describe("Watcher controller", func() {
 			DeferCleanup(keystone.DeleteKeystoneAPI, keystone.CreateKeystoneAPI(watcherTest.WatcherAPI.Namespace))
 			DeferCleanup(
 				k8sClient.Delete, ctx, th.CreateSecret(
+					types.NamespacedName{Namespace: watcherTest.Instance.Namespace, Name: "combined-ca-bundle"},
+					map[string][]byte{
+						"tls-ca-bundle.pem": []byte("other-b64-text"),
+					},
+				))
+			DeferCleanup(
+				k8sClient.Delete, ctx, th.CreateSecret(
 					types.NamespacedName{Namespace: watcherTest.Instance.Namespace, Name: "custom-prometheus-config"},
 					map[string][]byte{
 						"host":      []byte("customprometheus.example.com"),

--- a/tests/functional/watcher_test_data.go
+++ b/tests/functional/watcher_test_data.go
@@ -57,6 +57,8 @@ type WatcherTestData struct {
 	WatcherKeystoneEndpointName      types.NamespacedName
 	WatcherApplier                   types.NamespacedName
 	WatcherApplierStatefulSet        types.NamespacedName
+	WatcherPublicCertSecret          types.NamespacedName
+	WatcherInternalCertSecret        types.NamespacedName
 }
 
 // GetWatcherTestData is a function that initialize the WatcherTestData
@@ -165,6 +167,14 @@ func GetWatcherTestData(watcherName types.NamespacedName) WatcherTestData {
 		WatcherApplierStatefulSet: types.NamespacedName{
 			Namespace: watcherName.Namespace,
 			Name:      "watcher-applier",
+		},
+		WatcherPublicCertSecret: types.NamespacedName{
+			Namespace: watcherName.Namespace,
+			Name:      "cert-watcher-public-svc",
+		},
+		WatcherInternalCertSecret: types.NamespacedName{
+			Namespace: watcherName.Namespace,
+			Name:      "cert-watcher-internal-svc",
 		},
 	}
 }

--- a/tests/kuttl/test-suites/default/watcher-api-scaling/01-assert.yaml
+++ b/tests/kuttl/test-suites/default/watcher-api-scaling/01-assert.yaml
@@ -245,6 +245,10 @@ status:
     reason: Ready
     status: "True"
     type: ServiceConfigReady
+  - message: Input data complete
+    reason: Ready
+    status: "True"
+    type: TLSInputReady
 ---
 apiVersion: apps/v1
 kind: StatefulSet

--- a/tests/kuttl/test-suites/default/watcher-api-service-override/01-assert.yaml
+++ b/tests/kuttl/test-suites/default/watcher-api-service-override/01-assert.yaml
@@ -245,6 +245,10 @@ status:
     reason: Ready
     status: "True"
     type: ServiceConfigReady
+  - message: Input data complete
+    reason: Ready
+    status: "True"
+    type: TLSInputReady
 ---
 apiVersion: apps/v1
 kind: StatefulSet

--- a/tests/kuttl/test-suites/default/watcher/01-assert.yaml
+++ b/tests/kuttl/test-suites/default/watcher/01-assert.yaml
@@ -254,6 +254,10 @@ status:
     reason: Ready
     status: "True"
     type: ServiceConfigReady
+  - message: Input data complete
+    reason: Ready
+    status: "True"
+    type: TLSInputReady
 ---
 apiVersion: apps/v1
 kind: StatefulSet

--- a/tests/kuttl/test-suites/default/watcher/04-assert.yaml
+++ b/tests/kuttl/test-suites/default/watcher/04-assert.yaml
@@ -230,6 +230,10 @@ status:
     reason: Ready
     status: "True"
     type: ServiceConfigReady
+  - message: Input data complete
+    reason: Ready
+    status: "True"
+    type: TLSInputReady
 ---
 apiVersion: apps/v1
 kind: StatefulSet


### PR DESCRIPTION
Introduce several changes needed to support TLS on the endpoints. This
change does:

- Use HTTPS in the api statefulset probes if TLS is used
- Ensure all controllers are watching the secrets they consume (most were missing the CA secret)
 - Create volumes for TLS certificates and copy them to the API pods
 - Validate TLS input in watcherapi controller
 
 Related: https://issues.redhat.com/browse/OSPRH-13020