### PR TITLE
Enable watcher_tempest_plugin tests in validation jobs

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -23,11 +23,16 @@
       watcher_hook: "{{ watcher_repo }}/ci/playbooks/deploy_watcher_service.yaml"
       watcher_coo_hook: "{{ watcher_repo }}/ci/playbooks/deploy_cluster_observability_operator.yaml"
       run_tempest: false
-      # Based on current testing, https://github.com/openstack-k8s-operators/watcher-operator/pull/47#issuecomment-2607474033
-      # We need decision engine and applier CRD to ready to run
-      # whole test suite
+      cifmw_test_operator_concurrency: 1
       cifmw_test_operator_tempest_include_list: |
-        watcher_tempest_plugin.tests.api.admin.test_api_discovery.TestApiDiscovery
+        watcher_tempest_plugin.*
+      # We need to exclude client_functional tests until we have watcherclient installed in the
+      # tempest container.
+      # Some strategies execution tests are failing. Excluding until the work on the watcher-tempest-plugin
+      # is finished upstream.
+      cifmw_test_operator_tempest_exclude_list: |
+        watcher_tempest_plugin.*client_functional.*
+        watcher_tempest_plugin.tests.scenario(?!.*\b(?:test_execute_workload_balancing|test_execute_host_maintenance|test_execute_vm_workload_consolidation)\b).*
       # Donot use openstack services containers from meta content provider master
       # job.
       cifmw_update_containers_openstack: false
@@ -67,6 +72,22 @@
           source: "{{ watcher_hook }}"
           extra_vars:
             watcher_catalog_image: "{{ content_provider_registry_ip }}:5001/openstack-k8s-operators/watcher-operator-index:{{ zuul.patchset }}"
+      cifmw_tempest_tempestconf_config:
+        overrides: |
+          compute.min_microversion 2.56
+          compute.min_compute_nodes 2
+          placement.min_microversion 1.29
+          compute-feature-enabled.live_migration true
+          compute-feature-enabled.block_migration_for_live_migration true
+          service_available.sg_core true
+          telemetry_services.metric_backends prometheus
+          telemetry.disable_ssl_certificate_validation true
+          telemetry.ceilometer_polling_interval 15
+          optimize.datasource ''
+      cifmw_test_operator_tempest_external_plugin:
+        - repository: "https://opendev.org/openstack/watcher-tempest-plugin.git"
+          changeRepository: "https://review.opendev.org/openstack/watcher-tempest-plugin"
+          changeRefspec: "refs/heads/master"
 
 - job:
     name: watcher-operator-validation

--- a/Makefile
+++ b/Makefile
@@ -380,6 +380,8 @@ WATCHER_API_IMAGE_URL_DEFAULT_MASTER ?= quay.io/podified-master-centos9/openstac
 WATCHER_DECISION_ENGINE_IMAGE_URL_DEFAULT_MASTER ?= quay.io/podified-master-centos9/openstack-watcher-decision-engine:current-podified
 WATCHER_APPLIER_IMAGE_URL_DEFAULT_MASTER ?= quay.io/podified-master-centos9/openstack-watcher-applier:current-podified
 
+WATCHER_SAMPLE_CR_PATH ?= config/samples/watcher_v1beta1_watcher.yaml
+
 .PHONY: watcher
 watcher: export WATCHER_API_IMAGE=${WATCHER_API_IMAGE_URL_DEFAULT_MASTER}
 watcher: export WATCHER_DECISION_ENGINE_IMAGE=${WATCHER_DECISION_ENGINE_IMAGE_URL_DEFAULT_MASTER}
@@ -393,7 +395,7 @@ watcher: ## Install watcher operator via olm
 
 .PHONY: watcher_deploy
 watcher_deploy: ## Deploy watcher service
-	oc apply -f config/samples/watcher_v1beta1_watcher.yaml
+	oc apply -f ${WATCHER_SAMPLE_CR_PATH}
 	oc wait watcher watcher --for condition=Ready --timeout=600s
 
 .PHONY: watcher_deploy_cleanup

--- a/ci/playbooks/deploy_watcher_service.yaml
+++ b/ci/playbooks/deploy_watcher_service.yaml
@@ -45,3 +45,5 @@
         output_dir: "{{ cifmw_basedir }}/artifacts"
         chdir: "{{ ansible_user_dir }}/src/github.com/openstack-k8s-operators/watcher-operator"
         script: make watcher_deploy
+        extra_args:
+          WATCHER_SAMPLE_CR_PATH: "{{ watcher_cr_file | default('ci/watcher_v1beta1_watcher.yaml') }}"

--- a/ci/watcher_v1beta1_watcher.yaml
+++ b/ci/watcher_v1beta1_watcher.yaml
@@ -1,0 +1,15 @@
+apiVersion: watcher.openstack.org/v1beta1
+kind: Watcher
+metadata:
+  name: watcher
+spec:
+  databaseInstance: "openstack"
+  apiServiceTemplate:
+    tls:
+      caBundleSecretName: "combined-ca-bundle"
+  decisionengineServiceTemplate:
+    customServiceConfig: |
+      [watcher_cluster_data_model_collectors.compute]
+      period = 60
+      [watcher_cluster_data_model_collectors.storage]
+      period = 60


### PR DESCRIPTION
We have decision-engine and applier integrated in the Watcher controller so we can increase tempest coverage. I am excluding some tests from the watcher plugin:

- client_functional tests require watcherclient installed in the tempest  container.
- strategies execute tests are failing with an error while accessing resource traits for compute nodes. Until we can manage this, we can exclude these tests.

Also this patch is setting some tempest parameters aligned with upstream     ones and forcing to use the watcher-tempest-pluging from upstream master branch source instead of rpm.

Resolves: https://issues.redhat.com/browse/OSPRH-12114