### PR TITLE
Add a var to override watcher services tag

### DIFF
--- a/ci/playbooks/deploy_watcher_service.yaml
+++ b/ci/playbooks/deploy_watcher_service.yaml
@@ -20,7 +20,7 @@
 
     - name: Install Watcher Operator
       vars:
-        _tag: "{{ latest_dlrn_tag.content | default('current-podified') }}"
+        _tag: "{{ latest_dlrn_tag.content | default(watcher_services_tag) | default('current-podified') }}"
         # When there is no Depends-On from opendev, then content_provider_os_registry_url will return null
         # value to child job. In that case, we need to set default to quay registry.
         _registry_url: >-


### PR DESCRIPTION
When running a provider job that build openstack services, we may want to provide a specific tag defined in a dependent job, not from delorean or the default one.