### PR TITLE
Use stable channel for COO installation

### DIFF
--- a/ci/olm.sh
+++ b/ci/olm.sh
@@ -6,7 +6,7 @@ metadata:
   name: cluster-observability-operator
   namespace: openshift-operators
 spec:
-  channel: development
+  channel: stable
   installPlanApproval: Automatic
   name: cluster-observability-operator
   source: redhat-operators

--- a/ci/playbooks/deploy_cluster_observability_operator.yaml
+++ b/ci/playbooks/deploy_cluster_observability_operator.yaml
@@ -21,7 +21,7 @@
             name: cluster-observability-operator
             namespace: openshift-operators
           spec:
-            channel: development
+            channel: stable
             installPlanApproval: Automatic
             name: cluster-observability-operator
             source: redhat-operators


### PR DESCRIPTION
For some reason, we are using `development` channel which is not longer found in the redhat catalog for COO.