### PR TITLE
Use stable channel for COO

### DIFF
--- a/ci/playbooks/deploy_cluster_observability_operator.yaml
+++ b/ci/playbooks/deploy_cluster_observability_operator.yaml
@@ -21,7 +21,7 @@
             name: cluster-observability-operator
             namespace: openshift-operators
           spec:
-            channel: development
+            channel: stable
             installPlanApproval: Automatic
             name: cluster-observability-operator
             source: redhat-operators


### PR DESCRIPTION
The cluster observabilty operator recnetly
reached 1.0 and no longer publishes a development
channel.

This change updates our ci playbooks to use stable instead.
This is a port of
https://github.com/openstack-k8s-operators/telemetry-operator/pull/621
