### PR TITLE
add renovate confiugration

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,18 @@
+{
+  "extends": [
+    "github>openstack-k8s-operators/renovate-config:default.json5"
+  ],
+  "baseBranches": ["main"],
+  "useBaseBranchConfig": "merge",
+  "packageRules": [
+    {
+      "matchPackageNames": ["github.com/openstack-k8s-operators/watcher-operator/api"],
+      "enabled": false
+    }
+  ],
+  "postUpgradeTasks": {
+    "commands": ["make gowork", "make tidy", "make manifests generate"],
+    "fileFilters": ["**/go.mod", "**/go.sum", "**/*.go", "**/*.yaml"],
+    "executionMode": "update"
+  }
+}


### PR DESCRIPTION
renovate is used to manage our depnecies in a corrdinated way
across all the operators

this change enables renovate for the watcher operator
