### PR TITLE
unpin REXML documemtion dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,3 @@ gem 'asciidoctor', '~> 2.0', '>= 2.0.20'
 
 # Uncomment for ability to convert Markdown to AsciiDoc
 gem 'kramdown-asciidoc'
-
-# Needed for https://github.com/ruby/rexml/issues/131#issuecomment-2116267578
-gem 'rexml', '= 3.2.6'


### PR DESCRIPTION
the REXML modle was previously pinned to a verion with several
know cves related to regex perforamce.

this change removes the cap and set 3.3.9 as our new minium
requirement as that is the first release with no known vulnerablities
