### PR TITLE
Deploy Watcher with TLS in one of the validation jobs

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -98,7 +98,7 @@
       During watcher deployment, It will fetch master current-podified hash and pull
       openstack watcher services containers from meta content provider.
       It will test current-podified control plane EDPM deployment with openstack watcher
-      master content.
+      master content. It deploys watcher using TLSe, and creates the certificates to use.
     extra-vars:
       # Override zuul meta content provider provided content_provider_dlrn_md5_hash
       # var. As returned dlrn md5 hash comes from master release but job is using
@@ -108,6 +108,7 @@
       # Donot use openstack services containers from meta content provider master
       # job.
       cifmw_update_containers_openstack: false
+      watcher_cr_file: "ci/watcher_v1beta1_watcher_tlse.yaml"
 
 - job:
     name: watcher-operator-kuttl

--- a/ci/watcher_v1beta1_watcher_tlse.yaml
+++ b/ci/watcher_v1beta1_watcher_tlse.yaml
@@ -1,0 +1,83 @@
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: watcher-internal-svc
+spec:
+  dnsNames:
+  - watcher-internal.openstack.svc
+  - watcher-internal.openstack.svc.cluster.local
+  duration: 43800h0m0s
+  issuerRef:
+    group: cert-manager.io
+    kind: Issuer
+    name: rootca-internal
+  secretName: cert-watcher-internal-svc
+  usages:
+  - key encipherment
+  - digital signature
+  - server auth
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: watcher-public-route
+spec:
+  dnsNames:
+  - watcher-public-openstack.apps-crc.testing
+  issuerRef:
+    group: cert-manager.io
+    kind: Issuer
+    name: rootca-public
+  secretName: cert-watcher-public-route
+  usages:
+  - key encipherment
+  - digital signature
+  - server auth
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: watcher-public-svc
+spec:
+  dnsNames:
+  - watcher-public.openstack.svc
+  - watcher-public.openstack.svc.cluster.local
+  duration: 43800h0m0s
+  issuerRef:
+    group: cert-manager.io
+    kind: Issuer
+    name: rootca-public
+  secretName: cert-watcher-public-svc
+  usages:
+  - key encipherment
+  - digital signature
+  - server auth
+---
+apiVersion: watcher.openstack.org/v1beta1
+kind: Watcher
+metadata:
+  name: watcher
+spec:
+  databaseInstance: "openstack"
+  apiOverride:
+    tls:
+      secretName: cert-watcher-public-route
+  apiServiceTemplate:
+    override:
+      service:
+        public:
+          endpointURL: https://watcher-public-openstack.apps-crc.testing
+    tls:
+      caBundleSecretName: "combined-ca-bundle"
+      api:
+        internal:
+          secretName: cert-watcher-internal-svc
+        public:
+          secretName: cert-watcher-public-svc
+  decisionengineServiceTemplate:
+    customServiceConfig: |
+      [watcher_cluster_data_model_collectors.compute]
+      period = 60
+      [watcher_cluster_data_model_collectors.storage]
+      period = 60


### PR DESCRIPTION
Change one of the validation jobs to deploy watcher with TLSe. For now,
this means we also need to create certificates and set the right
secrets in the Watcher CR.

Depends-On: https://github.com/openstack-k8s-operators/watcher-operator/pull/57
