### PR TITLE
Fix the image name in deploy_watcher_service hook

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -376,16 +376,16 @@ update-watcher-csv:
 	fi
 
 CATALOG_IMAGE ?= quay.io/openstack-k8s-operators/watcher-operator-index:latest
-WATCHER_API_IMAGE_URL_DEFAULT_MASTER ?= quay.io/podified-master-centos9/openstack-watcher-api:current-podified
-WATCHER_DECISION_ENGINE_IMAGE_URL_DEFAULT_MASTER ?= quay.io/podified-master-centos9/openstack-watcher-decision-engine:current-podified
-WATCHER_APPLIER_IMAGE_URL_DEFAULT_MASTER ?= quay.io/podified-master-centos9/openstack-watcher-applier:current-podified
+WATCHER_API_CI_IMAGE ?= quay.io/podified-master-centos9/openstack-watcher-api:current-podified
+WATCHER_DECISION_ENGINE_CI_IMAGE ?= quay.io/podified-master-centos9/openstack-watcher-decision-engine:current-podified
+WATCHER_APPLIER_CI_IMAGE ?= quay.io/podified-master-centos9/openstack-watcher-applier:current-podified
 
 WATCHER_SAMPLE_CR_PATH ?= config/samples/watcher_v1beta1_watcher.yaml
 
 .PHONY: watcher
-watcher: export WATCHER_API_IMAGE=${WATCHER_API_IMAGE_URL_DEFAULT_MASTER}
-watcher: export WATCHER_DECISION_ENGINE_IMAGE=${WATCHER_DECISION_ENGINE_IMAGE_URL_DEFAULT_MASTER}
-watcher: export WATCHER_APPLIER_IMAGE=${WATCHER_APPLIER_IMAGE_URL_DEFAULT_MASTER}
+watcher: export WATCHER_API_IMAGE=${WATCHER_API_CI_IMAGE}
+watcher: export WATCHER_DECISION_ENGINE_IMAGE=${WATCHER_DECISION_ENGINE_CI_IMAGE}
+watcher: export WATCHER_APPLIER_IMAGE=${WATCHER_APPLIER_CI_IMAGE}
 watcher: export CATALOG_IMG=${CATALOG_IMAGE}
 watcher: ## Install watcher operator via olm
 	bash ci/olm.sh
@@ -461,9 +461,9 @@ SKIP_CERT ?=false
 .PHONY: run-with-webhook
 run-with-webhook: export METRICS_PORT?=33080
 run-with-webhook: export HEALTH_PORT?=33081
-run-with-webhook: export RELATED_IMAGE_WATCHER_API_IMAGE_URL_DEFAULT=${WATCHER_API_IMAGE_URL_DEFAULT_MASTER}
-run-with-webhook: export RELATED_IMAGE_WATCHER_DECISION_ENGINE_IMAGE_URL_DEFAULT=${WATCHER_DECISION_ENGINE_IMAGE_URL_DEFAULT_MASTER}
-run-with-webhook: export RELATED_IMAGE_WATCHER_APPLIER_IMAGE_URL_DEFAULT=${WATCHER_APPLIER_IMAGE_URL_DEFAULT_MASTER}
+run-with-webhook: export RELATED_IMAGE_WATCHER_API_IMAGE_URL_DEFAULT=${WATCHER_API_CI_IMAGE}
+run-with-webhook: export RELATED_IMAGE_WATCHER_DECISION_ENGINE_IMAGE_URL_DEFAULT=${WATCHER_DECISION_ENGINE_CI_IMAGE}
+run-with-webhook: export RELATED_IMAGE_WATCHER_APPLIER_IMAGE_URL_DEFAULT=${WATCHER_APPLIER_CI_IMAGE}
 run-with-webhook: manifests generate fmt vet ## Run a controller from your host.
 	/bin/bash hack/clean_local_webhook.sh
 	/bin/bash hack/run_with_local_webhook.sh

--- a/ci/playbooks/deploy_watcher_service.yaml
+++ b/ci/playbooks/deploy_watcher_service.yaml
@@ -35,9 +35,9 @@
         script: make watcher
         extra_args:
           CATALOG_IMAGE: "{{ watcher_catalog_image | default('quay.io/openstack-k8s-operators/watcher-operator-index:latest') }}"
-          RELATED_IMAGE_WATCHER_API_IMAGE_URL_DEFAULT: "{{ _registry_url }}/openstack-watcher-api:{{ _tag }}"
-          RELATED_IMAGE_WATCHER_DECISION_ENGINE_IMAGE_URL_DEFAULT: "{{ _registry_url }}/openstack-watcher-decision-engine:{{ _tag }}"
-          RELATED_IMAGE_WATCHER_APPLIER_IMAGE_URL_DEFAULT: "{{ _registry_url }}/openstack-watcher-applier:{{ _tag }}"
+          WATCHER_API_CI_IMAGE: "{{ _registry_url }}/openstack-watcher-api:{{ _tag }}"
+          WATCHER_DECISION_ENGINE_CI_IMAGE: "{{ _registry_url }}/openstack-watcher-decision-engine:{{ _tag }}"
+          WATCHER_APPLIER_CI_IMAGE: "{{ _registry_url }}/openstack-watcher-applier:{{ _tag }}"
 
     - name: Deploy Watcher service
       when: deploy_watcher_service | default('true') | bool


### PR DESCRIPTION
The correct vars passed to make watcher are as follow[1]: WATCHER_API_IMAGE,  WATCHER_DECISION_ENGINE_IMAGE and WATCHER_APPLIER_IMAGE. We need to use the same var in deploy_watcher_service hook.