### PR TITLE
Use openstack-check pipeline to run EDPM job on watcher opendev repos

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -205,8 +205,8 @@
     description: |
       Project template to run meta content provider and
       EDPM job with master opendev and github operator
-      content in openstack-experimental pipeline.
-    openstack-experimental:
+      content in openstack-check pipeline.
+    openstack-check:
       jobs:
         - openstack-meta-content-provider-master
         - watcher-operator-validation-master


### PR DESCRIPTION
Currently openstack-experimental pipeline used to run EDPM jobs on watcher opendev repos. But we want to run openstack-check pipeline on each watcher prs in order to make sure it does not break EDPM jobs.
    
This pr updates the pipeline to openstack-check. It will provide feedback on each patches via rdo third party check job.
