### PR TITLE
Add the route certificate to Watcher CR in install documentation

### DIFF
--- a/docs/install_guide.adoc
+++ b/docs/install_guide.adoc
@@ -275,6 +275,9 @@ metadata:
 spec:
   databaseInstance: "openstack"
   secret: <name of the secret with the credentials of the ControlPlane deploy>
+  apiOverride:
+    tls:
+      secretName: cert-watcher-public-route
   apiServiceTemplate:
     override:
       service:


### PR DESCRIPTION
It is required to deploy with TLS.