### PR TITLE
Remove non-standalone operatory-type for watcher-operator

### DIFF
--- a/config/manifests/bases/watcher-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/watcher-operator.clusterserviceversion.yaml
@@ -12,7 +12,6 @@ metadata:
     features.operators.openshift.io/token-auth-azure: "false"
     features.operators.openshift.io/token-auth-gcp: "false"
     operatorframework.io/suggested-namespace: openstack
-    operators.operatorframework.io/operator-type: non-standalone
   name: watcher-operator.v0.0.0
   namespace: placeholder
 spec:


### PR DESCRIPTION
We need to be available in the WebUI to be installed standalone.

Closes: https://issues.redhat.com/browse/OSPRH-14724