### PR TITLE
Revert "Remove non-standalone operatory-type for watcher-operator"

### DIFF
--- a/config/manifests/bases/watcher-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/watcher-operator.clusterserviceversion.yaml
@@ -12,6 +12,7 @@ metadata:
     features.operators.openshift.io/token-auth-azure: "false"
     features.operators.openshift.io/token-auth-gcp: "false"
     operatorframework.io/suggested-namespace: openstack
+    operators.operatorframework.io/operator-type: non-standalone
   name: watcher-operator.v0.0.0
   namespace: placeholder
 spec:


### PR DESCRIPTION
Reverts openstack-k8s-operators/watcher-operator#109
this enabled a funcitonalty that was intentionally disabled.