### PR TITLE
Remove prometheus graphic & update service result

### DIFF
--- a/docs/install_guide.adoc
+++ b/docs/install_guide.adoc
@@ -35,8 +35,6 @@ $ oc rsh openstackclient openstack endpoint list -c 'ID' -c 'Service Name' -c 'E
 | 0bada656064a4d409bc5fed610654edd | neutron      | True    |
 | 17453066f8dc40bfa0f8584007cffc9a | cinderv3     | True    |
 | 22768bf3e9a34fefa57b96c20d405cfe | keystone     | True    |
-| 284fd13676ed4bb095b602a004b4a0f2 | watcher      | True    |
-| 48602a17288f442a98c300931f82244a | watcher      | True    |
 | 54e3d48cdda84263b7f1c65c924f3e3a | glance       | True    |
 | 74345a18262740eb952d2b6b7220ceeb | keystone     | True    |
 | 789a2d6048174b849a7c7243421675b4 | placement    | True    |

--- a/docs/user_workflow.adoc
+++ b/docs/user_workflow.adoc
@@ -342,14 +342,7 @@ for the new Audit. Given the low usage of resources in the instances created for
 workflows, the initial `Action Plan` will not have real actions.
 
 . Increase CPU consumption in one of the created instances (VMs).
-You can find the CPU usage of each instance at the example URL:
-https://metric-storage-prometheus-openstack.apps-crc.testing/graph?g0.expr=clamp_max((avg%20by%20(resource)(rate(ceilometer_cpu%5B150s%5D))%2F10e%2B8)%20*(100%2F1)%2C%20100)&g0.tab=0&g0.display_mode=lines&g0.show_exemplars=0&g0.range_input=1h[Prometheus Metrics]
-+
-
-image::prometheus_metrics.png[]
-
-+
-View the list of instances in `Horizon` by selecting the *Instances* panel from the menus:
+You can view the list of instances in `Horizon` by selecting the *Instances* panel from the menus:
 *Admin* -> *Compute* -> *Instances*.
 Click on the name of one of the instances, and go to the *Console* tab for that instance.
 Log in with `cirros` user and the `gocubsgo` password, and run following command:


### PR DESCRIPTION
This PR fixes the install guide to remove the watcher service showing as available before installation.
It also remove a link that is no longer available.