### PR TITLE
Set merge-mode for project openstack-k8s-operators/watcher-operator

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -2,6 +2,7 @@
 - project:
     name: openstack-k8s-operators/watcher-operator
     default-branch: main
+    merge-mode: rebase
     templates:
       - opendev-master-watcher-operator-pipeline
     github-check:


### PR DESCRIPTION
This is failed due to no having the right merge-mode [1] set.

https://softwarefactory-project.io/zuul/t/rdoproject.org/config-errors?project=openstack-k8s-operators%2Fwatcher-operator&skip=0

[1] https://zuul-ci.org/docs/zuul/latest/config/project.html#attr-project.merge-mode

Depends-On: https://github.com/openstack-k8s-operators/ci-framework/pull/2826