### PR TITLE
Remove description field from project-template

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -205,10 +205,6 @@
 
 - project-template:
     name: opendev-master-watcher-operator-pipeline
-    description: |
-      Project template to run meta content provider and
-      EDPM job with master opendev and github operator
-      content.
     github-check:
       jobs:
         - openstack-meta-content-provider-master
@@ -217,10 +213,6 @@
 
 - project-template:
     name: opendev-watcher-edpm-pipeline
-    description: |
-      Project template to run meta content provider and
-      EDPM job with master opendev and github operator
-      content in openstack-check pipeline.
     openstack-check:
       jobs:
         - openstack-meta-content-provider-master


### PR DESCRIPTION
This change removes the description field from project/project-template. This is not a valid field, check the documentation [1].

[1] - https://zuul-ci.org/docs/zuul/latest/config/project.html#project-template

Depends-On: https://github.com/openstack-k8s-operators/ci-framework/pull/2826