### PR TITLE
Run build job in 18.0-fr* branches

### DIFF
--- a/.github/workflows/build-watcher-operator.yaml
+++ b/.github/workflows/build-watcher-operator.yaml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - 'main'
+      - '18.0-fr*'
 
 env:
   imageregistry: 'quay.io'


### PR DESCRIPTION
So that we get the containers images for FR2 branch too.