### PR TITLE
Suggest to install watcher-operator in openstack-operators

### DIFF
--- a/config/manifests/bases/watcher-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/watcher-operator.clusterserviceversion.yaml
@@ -11,7 +11,7 @@ metadata:
     features.operators.openshift.io/token-auth-aws: "false"
     features.operators.openshift.io/token-auth-azure: "false"
     features.operators.openshift.io/token-auth-gcp: "false"
-    operatorframework.io/suggested-namespace: openstack
+    operatorframework.io/suggested-namespace: openstack-operators
   name: watcher-operator.v0.0.0
   namespace: placeholder
 spec:


### PR DESCRIPTION
Currently, OLM suggests to install the operator in `openstack` while it should be installed in `openstack-operators`.

This patch is setting operatorframework.io/suggested-namespace [1] to `openstack-operators` as the openstack operator does [2].

Resolves: https://issues.redhat.com/browse/OSPRH-15432

[1] https://docs.redhat.com/en/documentation/openshift_container_platform/4.16/html/operators/developing-operators#osdk-csv-manual-annotations-deprecated_osdk-generating-csvs
[2] https://github.com/openstack-k8s-operators/openstack-operator/blob/d648626207ce2cbfebe219a01456f4f87b2abc4d/config/manifests/bases/openstack-operator.clusterserviceversion.yaml#L14