### PR TITLE
Skip real_data tests from watcher tempest plugin

### DIFF
--- a/ci/tests/watcher-master.yml
+++ b/ci/tests/watcher-master.yml
@@ -31,6 +31,7 @@ cifmw_test_operator_tempest_include_list: |
 cifmw_test_operator_tempest_exclude_list: |
   watcher_tempest_plugin.*client_functional.*
   watcher_tempest_plugin.tests.scenario.test_execute_strategies.TestExecuteStrategies.test_execute_storage_capacity_balance_strategy
+  watcher_tempest_plugin.*\[.*\breal_load\b.*\].*
 
 # Tempest images cases
 # content_provider_os_registry_url is not null, It means an opendev depends-on is used


### PR DESCRIPTION
Until we refine the configuration of real and injected data in the same job, let's skip real data ones.

Required for https://review.opendev.org/c/openstack/watcher-tempest-plugin/+/940171 