### PR TITLE
Skip openstack-check jobs on opendev watcher .zuul.yaml changes

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -224,6 +224,7 @@
               - ^setup.cfg$
               - ^tools/.*$
               - ^tox.ini$
+              - ^.zuul.yaml
             # Build watcher-operator always in meta content provider
             vars:
               cifmw_operator_build_operators:


### PR DESCRIPTION
openstack-check jobs runs content provider and edpm jobs. It does not have any relationship with .zuul.yaml. So skip running openstack-check pipeline on these changes to avoid wasting resources.