### PR TITLE
Add force-bump-pull-request workflows

### DIFF
--- a/.github/workflows/force-bump-pr-manual.yaml
+++ b/.github/workflows/force-bump-pr-manual.yaml
@@ -1,0 +1,13 @@
+name: Manually Trigger a Force Bump PR
+
+on:
+  workflow_dispatch:
+
+jobs:
+  call-build-workflow:
+    uses: openstack-k8s-operators/openstack-k8s-operators-ci/.github/workflows/force-bump-pull-request.yaml@main
+    with:
+      operator_name: watcher
+      branch_name: ${{ github.ref_name }}
+    secrets:
+      FORCE_BUMP_PULL_REQUEST_PAT: ${{ secrets.FORCE_BUMP_PULL_REQUEST_PAT }}

--- a/.github/workflows/force-bump-pr-scheduled.yaml
+++ b/.github/workflows/force-bump-pr-scheduled.yaml
@@ -1,0 +1,14 @@
+name: Scheduled Force Bump PR
+
+on:
+  schedule:
+    - cron: '0 7 * * 6'  # 7AM UTC Saturday
+
+jobs:
+  call-build-workflow:
+    if: github.ref == 'refs/heads/main' && github.repository_owner == 'openstack-k8s-operators'
+    uses: openstack-k8s-operators/openstack-k8s-operators-ci/.github/workflows/force-bump-branches.yaml@main
+    with:
+      operator_name: watcher
+    secrets:
+      FORCE_BUMP_PULL_REQUEST_PAT: ${{ secrets.FORCE_BUMP_PULL_REQUEST_PAT }}


### PR DESCRIPTION
Adds two new workflows to create force bump PRs

The manual version can be triggered via the github actions tab.

The scheduled version runs on Saturday and will generate PRs for main and the most recent FR branch.

Jira: [OSPRH-8379](https://issues.redhat.com//browse/OSPRH-8379)