### PR TITLE
Repurpose periodic watcher validation job to test cs10 master containers

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -35,7 +35,7 @@
     description: |
       A multinode EDPM Zuul job which has one ansible controller, one
       extracted crc and two computes. It will be used for testing watcher
-      in the master promotion RDO pipeline.
+      in the master promotion RDO pipeline with CentOS Stream 10 content.
     vars:
       cifmw_repo_setup_branch: master
       cifmw_repo_setup_promotion: podified-ci-testing
@@ -52,9 +52,17 @@
            src_dir }}/ci/scenarios/edpm.yml"
         - "@{{ ansible_user_dir }}/{{ zuul.projects['github.com/openstack-k8s-operators/watcher-operator'].
            src_dir }}/ci/tests/watcher-master.yml"
-      fetch_dlrn_hash: true
-      watcher_dlrn_tag: "{{ cifmw_repo_setup_promotion }}"
-      watcher_registry_url: quay.rdoproject.org/podified-master-centos9
+      fetch_dlrn_hash: false
+      # Note(chandankumar): It tests cs10 master container current tag build from
+      # DLRN current.
+      watcher_dlrn_tag: current
+      watcher_registry_url: quay.rdoproject.org/podified-master-centos10
+      cifmw_update_containers_registry: "{{ watcher_registry_url | split('/') | first }}"
+      cifmw_update_containers_tag: current
+      cifmw_update_containers_org: "{{ watcher_registry_url | split('/') | last }}"
+      cifmw_test_operator_tempest_image_tag: current
+      cifmw_test_operator_tempest_registry: "{{ cifmw_update_containers_registry }}"
+      cifmw_test_operator_tempest_namespace: "{{ cifmw_update_containers_org }}"
 
 - job:
     name: watcher-operator-validation-base
@@ -292,7 +300,6 @@
               - ^setup.cfg$
               - ^tools/.*$
               - ^tox.ini$
-              - ^.zuul.yaml
             # Build watcher-operator always in meta content provider
             vars:
               cifmw_operator_build_operators:


### PR DESCRIPTION
With https://github.com/openstack-k8s-operators/watcher-operator/pull/159#issuecomment-2888916218, CS10 EDPM POC job is now working with tls.

https://review.rdoproject.org/r/c/rdo-jobs/+/57650 pushes containers with current tag in master integration line.
    
Let's reuse this line to test cs10 master current containers.
   
Depends-On: https://github.com/openstack-k8s-operators/openstack-operator/pull/1443

Resolves: https://issues.redhat.com//browse/OSPRH-16721
    
