### PR TITLE
Replace antelope-controlplane + master-watcher jobs by antelope + epoxy

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -10,7 +10,6 @@
       jobs:
         - noop
         - watcher-operator-doc-preview
-        - watcher-operator-validation
         - watcher-operator-kuttl
 
 - job:
@@ -197,6 +196,12 @@
       cifmw_test_operator_tempest_namespace: "{{ content_provider_os_registry_url | split('/') | last }}"
       cifmw_test_operator_tempest_image_tag: watcher_latest
 
+- job:
+    name: watcher-operator-validation-epoxy-ocp4-16
+    parent: watcher-operator-validation-epoxy
+    description: |
+      watcher-operator-validation qualification with OCP 4.16
+    nodeset: centos-9-medium-2x-centos-9-crc-extracted-2-39-0-xxl
 
 ##########################################################
 #                                                        #
@@ -254,7 +259,6 @@
       jobs:
         - openstack-meta-content-provider-master
         - watcher-operator-validation-master
-        - watcher-operator-validation-ocp4-16
 
 - project-template:
     name: opendev-epoxy-watcher-operator-pipeline
@@ -262,6 +266,7 @@
       jobs:
         - openstack-meta-content-provider-epoxy
         - watcher-operator-validation-epoxy
+        - watcher-operator-validation-epoxy-ocp4-16
 
 - project-template:
     name: opendev-watcher-edpm-pipeline


### PR DESCRIPTION
master branch is not longer supported in centos9 (python3.9) upstream, so we should avoid using it specially in a stable job with antelope based controlplane.

This patch is replacing the jobs using watcher from master in antelope controlplane jobs by epoxy based watcher containers. The resulting testing combination is:

1. Antelope controlplane + epoxy watcher (centos 9)
- Job on ocp 4.18
- Job on ocp 4.16

2. Master controlplane + master watcher (centos 9)
- Job on ocp 4.18

Note we will need to migrate [2] to centos10 which is work in progress right now.