### PR TITLE
Change memcache to use memcache_pool driver

### DIFF
--- a/templates/00-default.conf
+++ b/templates/00-default.conf
@@ -61,14 +61,19 @@ datasources = prometheus
 {{ if (index . "MemcachedServers") }}
 [cache]
 {{ if .MemcachedTLS }}
-backend = dogpile.cache.pymemcache
+backend = oslo_cache.memcache_pool
 memcache_servers={{ .MemcachedServers }}
+memcache_socket_timeout = 0.5
+memcache_pool_connection_get_timeout = 1
+# workaround to force bmemcache driver
+memcache_sasl_enabled = true
 {{ else }}
 backend = dogpile.cache.memcached
 memcache_servers={{ .MemcachedServersWithInet }}
 {{ end }}
 enabled=true
 tls_enabled={{ .MemcachedTLS }}
+memcache_dead_retry = 30
 {{ end }}
 
 {{ if (index . "PrometheusHost") }}


### PR DESCRIPTION
In HA tests it was identified that pymemcache backend does not recover/fail over to the next memcache instance when one goes away unexpected. Using memcache_pool with bmemcache does failover properly.

The memcache_sasl_enable=true is a workaround to force oslo.cache to switch to the bmemcache driver, which is the only driver in memcache_pool supporting tls+fips.

Jira: [OSPRH-16651](https://issues.redhat.com//browse/OSPRH-16651)

Co-outhored-by: Luca Miccini <lmiccini@redhat.com>