### PR TITLE
[18.0-fr2] Replace antelope-controlplane + master-watcher jobs by antelope + epoxy

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -5,6 +5,7 @@
     merge-mode: rebase
     templates:
       - opendev-master-watcher-operator-pipeline
+      - opendev-epoxy-watcher-operator-pipeline
     github-check:
       jobs:
         - noop
@@ -150,6 +151,61 @@
 
 ##########################################################
 #                                                        #
+#               Epoxy Zuul Jobs                          #
+#                                                        #
+##########################################################
+- job:
+    name: openstack-meta-content-provider-epoxy
+    description: |
+      A zuul job building content from OpenDev epoxy release.
+    parent: openstack-meta-content-provider
+    pre-run:
+      - ci/playbooks/copy_container_files.yaml
+    vars:
+      cifmw_operator_build_meta_build: false
+      cifmw_bop_openstack_release: epoxy
+      cifmw_bop_dlrn_baseurl: "https://trunk.rdoproject.org/centos9-epoxy"
+      cifmw_repo_setup_branch: epoxy
+      cifmw_build_containers_registry_namespace: podified-epoxy-centos9
+      cifmw_build_containers_config_file: "{{ ansible_user_dir }}/containers.yaml"
+      cifmw_repo_setup_promotion: podified-ci-testing
+      cifmw_build_containers_force: true
+      cifmw_build_containers_image_tag: watcher_latest
+
+- job:
+    name: watcher-operator-validation-epoxy
+    parent: watcher-operator-validation-base
+    dependencies: ["openstack-meta-content-provider-epoxy"]
+    description: |
+      A zuul job to validate the watcher operator and its service deployment.
+      It will deploy podified and EDPM using current-podified antelope content.
+      During watcher deployment, It will fetch epoxy current hash and pull
+      openstack watcher services containers from meta content provider.
+      It will test current-podified control plane EDPM deployment with openstack watcher
+      master content. It deploys watcher using TLSe, and creates the certificates to use.
+    extra-vars:
+      # Override zuul meta content provider provided content_provider_dlrn_md5_hash
+      # var. As returned dlrn md5 hash comes from master release but job is using
+      # antelope content.
+      content_provider_dlrn_md5_hash: ''
+    vars:
+      # Donot use openstack services containers from meta content provider master
+      # job.
+      cifmw_update_containers_openstack: false
+      # current dlrn hash changes frequently. In meta content provider, containers
+      # are tagged with watcher_latest, let's use the same here.
+      fetch_dlrn_hash: false
+      watcher_services_tag: watcher_latest
+      deploy_watcher_service_extra_vars:
+        watcher_cr_file: "ci/watcher_v1beta1_watcher_tlse.yaml"
+      # tempest vars
+      cifmw_test_operator_tempest_registry: "{{ content_provider_os_registry_url | split('/') | first }}"
+      cifmw_test_operator_tempest_namespace: "{{ content_provider_os_registry_url | split('/') | last }}"
+      cifmw_test_operator_tempest_image_tag: watcher_latest
+
+
+##########################################################
+#                                                        #
 #               Master Zuul Jobs                         #
 #                                                        #
 ##########################################################
@@ -199,6 +255,13 @@
             required-projects:
               - name: openstack-k8s-operators/ci-framework
                 override-checkout: main
+
+- project-template:
+    name: opendev-epoxy-watcher-operator-pipeline
+    github-check:
+      jobs:
+        - openstack-meta-content-provider-epoxy
+        - watcher-operator-validation-epoxy
 
 - project-template:
     name: opendev-watcher-edpm-pipeline

--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -10,10 +10,6 @@
       jobs:
         - noop
         - watcher-operator-doc-preview
-        - watcher-operator-validation:
-            required-projects:
-              - name: openstack-k8s-operators/ci-framework
-                override-checkout: main
         - watcher-operator-kuttl:
             required-projects:
               - name: openstack-k8s-operators/ci-framework
@@ -203,6 +199,12 @@
       cifmw_test_operator_tempest_namespace: "{{ content_provider_os_registry_url | split('/') | last }}"
       cifmw_test_operator_tempest_image_tag: watcher_latest
 
+- job:
+    name: watcher-operator-validation-epoxy-ocp4-16
+    parent: watcher-operator-validation-epoxy
+    description: |
+      watcher-operator-validation qualification with OCP 4.16
+    nodeset: centos-9-medium-2x-centos-9-crc-extracted-2-39-0-xxl
 
 ##########################################################
 #                                                        #
@@ -251,17 +253,23 @@
             required-projects:
               - name: openstack-k8s-operators/ci-framework
                 override-checkout: main
-        - watcher-operator-validation-ocp4-16:
-            required-projects:
-              - name: openstack-k8s-operators/ci-framework
-                override-checkout: main
 
 - project-template:
     name: opendev-epoxy-watcher-operator-pipeline
     github-check:
       jobs:
-        - openstack-meta-content-provider-epoxy
-        - watcher-operator-validation-epoxy
+        - openstack-meta-content-provider-epoxy:
+            required-projects:
+              - name: openstack-k8s-operators/ci-framework
+                override-checkout: main
+        - watcher-operator-validation-epoxy:
+            required-projects:
+              - name: openstack-k8s-operators/ci-framework
+                override-checkout: main
+        - watcher-operator-validation-epoxy-ocp4-16:
+            required-projects:
+              - name: openstack-k8s-operators/ci-framework
+                override-checkout: main
 
 - project-template:
     name: opendev-watcher-edpm-pipeline

--- a/ci/files/containers.yaml
+++ b/ci/files/containers.yaml
@@ -1,0 +1,5 @@
+container_images:
+- imagename: quay.io/podified-master-centos9/openstack-watcher-api:current-podified
+- imagename: quay.io/podified-master-centos9/openstack-watcher-applier:current-podified
+- imagename: quay.io/podified-master-centos9/openstack-watcher-decision-engine:current-podified
+- imagename: quay.io/podified-master-centos9/openstack-tempest-all:current-podified

--- a/ci/playbooks/copy_container_files.yaml
+++ b/ci/playbooks/copy_container_files.yaml
@@ -1,0 +1,9 @@
+---
+- name: Copy watcher containers.yaml file
+  hosts: all
+  tasks:
+    - name: Copy containers.yaml file
+      ansible.builtin.copy:
+        src: "{{ ansible_user_dir }}/src/github.com/openstack-k8s-operators/watcher-operator/ci/files/containers.yaml"
+        dest: "{{ ansible_user_dir }}/containers.yaml"
+        remote_src: true


### PR DESCRIPTION
master branch is not longer supported in centos9 (python3.9) upstream, so we should avoid using it specially in a stable job with antelope based controlplane.

This patch is replacing the jobs using watcher from master in antelope controlplane jobs by epoxy based watcher containers. The resulting testing combination is:

1. Antelope controlplane + epoxy watcher (centos 9)
    - Job on ocp 4.18
    - Job on ocp 4.16

2. Master controlplane + master watcher (centos 9)
    - Job on ocp 4.18
    
 Note we will need to migrate [2] to centos10 which is work in progress right now.

 This is a slightly modified backport of https://github.com/openstack-k8s-operators/watcher-operator/pull/165/

Also includes backport of https://github.com/openstack-k8s-operators/watcher-operator/pull/152