### PR TITLE
Make job watcher-operator-validation-master non-voting

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -231,6 +231,10 @@
 - job:
     name: watcher-operator-validation-master
     parent: watcher-operator-validation-base
+    # Note(Chandankumar): Make it voting once
+    # github.com/openstack-k8s-operators/watcher-operator/pull/168#issuecomment-2897402858
+    # resolves.
+    voting: false
     description: |
       A Zuul job consuming content from openstack-meta-content-provider-master
       and deploying EDPM with master content.


### PR DESCRIPTION
Until issue with memcached configuration is fixed [1].

[1] https://github.com/openstack-k8s-operators/watcher-operator/pull/168#issuecomment-2897402858