### PR TITLE
Update crc nodes to 3xl in 4.16 jobs

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -113,7 +113,7 @@
     parent: watcher-operator-validation
     description: |
       watcher-operator-validation qualification with OCP 4.16
-    nodeset: centos-9-medium-2x-centos-9-crc-extracted-2-39-0-xxl
+    nodeset: centos-9-medium-2x-centos-9-crc-extracted-2-39-0-3xl
 
 - job:
     name: watcher-operator-kuttl
@@ -209,7 +209,7 @@
     parent: watcher-operator-validation-epoxy
     description: |
       watcher-operator-validation qualification with OCP 4.16
-    nodeset: centos-9-medium-2x-centos-9-crc-extracted-2-39-0-xxl
+    nodeset: centos-9-medium-2x-centos-9-crc-extracted-2-39-0-3xl
 
 ##########################################################
 #                                                        #


### PR DESCRIPTION
Lately, we have been hitting resources issues in validation jobs running on 4.16 specially.

nova-operator is using 3xl size for crc in their jobs [1] and no resource issues are found in their logs, so I am proposing to update the crc node size to 3xl.

For 4.18 jobs we are inheriting the nodesets definition and seems more stable so I'm keeping them as-is so far.

[1] https://github.com/openstack-k8s-operators/nova-operator/blob/c71791ea3caa04b04445c59f935a335848f38861/.zuul.yaml#L60

Depends-On: https://github.com/openstack-k8s-operators/ci-framework/pull/3012