### PR TITLE
[master]Set memcache_sasl_enabled to false

### DIFF
--- a/ci/scenarios/edpm.yml
+++ b/ci/scenarios/edpm.yml
@@ -34,6 +34,21 @@ cifmw_edpm_prepare_kustomizations:
         metadata:
           name: unused
         spec:
+          nova:
+            template:
+              customServiceConfig: |
+                [cache]
+                memcache_sasl_enabled = false
+          neutron:
+            template:
+              customServiceConfig: |
+                [cache]
+                memcache_sasl_enabled = false
+          keystone:
+            template:
+              customServiceConfig: |
+                [cache]
+                memcache_sasl_enabled = false
           telemetry:
             enabled: true
             template:

--- a/templates/00-default.conf
+++ b/templates/00-default.conf
@@ -66,7 +66,7 @@ memcache_servers={{ .MemcachedServers }}
 memcache_socket_timeout = 0.5
 memcache_pool_connection_get_timeout = 1
 # workaround to force bmemcache driver
-memcache_sasl_enabled = true
+memcache_sasl_enabled = false
 {{ else }}
 backend = dogpile.cache.memcached
 memcache_servers={{ .MemcachedServersWithInet }}


### PR DESCRIPTION
keystone-bootstrap pod is failing with
```
ConfigurationError: username and password should be configured to use SASL authentication.
```

In order to fix this issue, [Use BMemcacheClientPool if tls_enabled=true](https://review.opendev.org/c/openstack/oslo.cache/+/950561)
got proposed upstream and backported in all release.

In order to fix this issue, we can workaround by
setting memcache_sasl_enabled to false.

Jira: [OSPRH-17029](https://issues.redhat.com//browse/OSPRH-17029)
Jira: [OSPRH-16651](https://issues.redhat.com//browse/OSPRH-16651)