### PR TITLE
Pass watcher_services_tag: current to periodic job

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -55,7 +55,7 @@
       fetch_dlrn_hash: false
       # Note(chandankumar): It tests cs10 master container current tag build from
       # DLRN current.
-      watcher_dlrn_tag: current
+      watcher_services_tag: current
       watcher_registry_url: quay.rdoproject.org/podified-master-centos10
       cifmw_update_containers_registry: "{{ watcher_registry_url | split('/') | first }}"
       cifmw_update_containers_tag: current


### PR DESCRIPTION
In periodic job, we test current tagged containers. Currently watcher-db-sync pod is hitting ImagepUlloff error due to current-podified usage.

The correct tag is current. Let's use watcher_services_tag to pass the correct tag.