### PR TITLE
Watch KeystoneAPI status updates to reconcile

### DIFF
--- a/controllers/watcherapi_controller.go
+++ b/controllers/watcherapi_controller.go
@@ -916,6 +916,9 @@ func (r *WatcherAPIReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Watches(&topologyv1.Topology{},
 			handler.EnqueueRequestsFromMapFunc(r.findObjectsForSrc),
 			builder.WithPredicates(predicate.GenerationChangedPredicate{})).
+		Watches(&keystonev1.KeystoneAPI{},
+			handler.EnqueueRequestsFromMapFunc(r.findObjectForSrc),
+			builder.WithPredicates(keystonev1.KeystoneAPIStatusChangedPredicate)).
 		Complete(r)
 }
 
@@ -948,6 +951,37 @@ func (r *WatcherAPIReconciler) findObjectsForSrc(ctx context.Context, src client
 				},
 			)
 		}
+	}
+
+	return requests
+}
+
+func (r *WatcherAPIReconciler) findObjectForSrc(ctx context.Context, src client.Object) []reconcile.Request {
+	requests := []reconcile.Request{}
+
+	l := log.FromContext(ctx).WithName("Controllers").WithName("WatcherAPI")
+
+	crList := &watcherv1beta1.WatcherAPIList{}
+	listOps := &client.ListOptions{
+		Namespace: src.GetNamespace(),
+	}
+	err := r.Client.List(ctx, crList, listOps)
+	if err != nil {
+		l.Error(err, fmt.Sprintf("listing %s for namespace: %s", crList.GroupVersionKind().Kind, src.GetNamespace()))
+		return requests
+	}
+
+	for _, item := range crList.Items {
+		l.Info(fmt.Sprintf("input source %s changed, reconcile: %s - %s", src.GetName(), item.GetName(), item.GetNamespace()))
+
+		requests = append(requests,
+			reconcile.Request{
+				NamespacedName: types.NamespacedName{
+					Name:      item.GetName(),
+					Namespace: item.GetNamespace(),
+				},
+			},
+		)
 	}
 
 	return requests

--- a/controllers/watcherapplier_controller.go
+++ b/controllers/watcherapplier_controller.go
@@ -493,6 +493,9 @@ func (r *WatcherApplierReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Watches(&topologyv1.Topology{},
 			handler.EnqueueRequestsFromMapFunc(r.findObjectsForSrc),
 			builder.WithPredicates(predicate.GenerationChangedPredicate{})).
+		Watches(&keystonev1.KeystoneAPI{},
+			handler.EnqueueRequestsFromMapFunc(r.findObjectForSrc),
+			builder.WithPredicates(keystonev1.KeystoneAPIStatusChangedPredicate)).
 		Complete(r)
 }
 
@@ -525,6 +528,37 @@ func (r *WatcherApplierReconciler) findObjectsForSrc(ctx context.Context, src cl
 				},
 			)
 		}
+	}
+
+	return requests
+}
+
+func (r *WatcherApplierReconciler) findObjectForSrc(ctx context.Context, src client.Object) []reconcile.Request {
+	requests := []reconcile.Request{}
+
+	l := log.FromContext(ctx).WithName("Controllers").WithName("WatcherApplier")
+
+	crList := &watcherv1beta1.WatcherApplierList{}
+	listOps := &client.ListOptions{
+		Namespace: src.GetNamespace(),
+	}
+	err := r.Client.List(ctx, crList, listOps)
+	if err != nil {
+		l.Error(err, fmt.Sprintf("listing %s for namespace: %s", crList.GroupVersionKind().Kind, src.GetNamespace()))
+		return requests
+	}
+
+	for _, item := range crList.Items {
+		l.Info(fmt.Sprintf("input source %s changed, reconcile: %s - %s", src.GetName(), item.GetName(), item.GetNamespace()))
+
+		requests = append(requests,
+			reconcile.Request{
+				NamespacedName: types.NamespacedName{
+					Name:      item.GetName(),
+					Namespace: item.GetNamespace(),
+				},
+			},
+		)
 	}
 
 	return requests

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/onsi/gomega v1.34.1
 	github.com/openshift/api v3.9.0+incompatible
 	github.com/openstack-k8s-operators/infra-operator/apis v0.6.1-0.20250530085921-2b2be72badf4
-	github.com/openstack-k8s-operators/keystone-operator/api v0.6.1-0.20250528115713-faa7ebf8f7fc
+	github.com/openstack-k8s-operators/keystone-operator/api v0.6.1-0.20250604143452-2260c431b9f1
 	github.com/openstack-k8s-operators/lib-common/modules/common v0.6.1-0.20250508141203-be026d3164f7
 	github.com/openstack-k8s-operators/lib-common/modules/test v0.6.1-0.20250508141203-be026d3164f7
 	github.com/openstack-k8s-operators/mariadb-operator/api v0.6.1-0.20250524131103-7ebaceec882b

--- a/go.sum
+++ b/go.sum
@@ -80,8 +80,8 @@ github.com/openshift/api v0.0.0-20240830023148-b7d0481c9094 h1:J1wuGhVxpsHykZBa6
 github.com/openshift/api v0.0.0-20240830023148-b7d0481c9094/go.mod h1:CxgbWAlvu2iQB0UmKTtRu1YfepRg1/vJ64n2DlIEVz4=
 github.com/openstack-k8s-operators/infra-operator/apis v0.6.1-0.20250530085921-2b2be72badf4 h1:FmgzhJRoXETu1zY+WJItpw3MEq+uR/7Gx5yXtfMs3UI=
 github.com/openstack-k8s-operators/infra-operator/apis v0.6.1-0.20250530085921-2b2be72badf4/go.mod h1:47iJk3vedZWnBkZyNyYij4ma2HjG4l2VCqKz3f+XDkQ=
-github.com/openstack-k8s-operators/keystone-operator/api v0.6.1-0.20250528115713-faa7ebf8f7fc h1:gYSgcZ4cCz41GIElVe122d4ZzoUQZ8ag886Pvse6HVU=
-github.com/openstack-k8s-operators/keystone-operator/api v0.6.1-0.20250528115713-faa7ebf8f7fc/go.mod h1:dgYQJbbVaRuP98yZZB3K1rNpqnF54I1HM1ZTaOzPKBY=
+github.com/openstack-k8s-operators/keystone-operator/api v0.6.1-0.20250604143452-2260c431b9f1 h1:YQuJwgoQ9mEyzNq9/SgS3wPCtLG0wMQWH/caWAMZeSc=
+github.com/openstack-k8s-operators/keystone-operator/api v0.6.1-0.20250604143452-2260c431b9f1/go.mod h1:dgYQJbbVaRuP98yZZB3K1rNpqnF54I1HM1ZTaOzPKBY=
 github.com/openstack-k8s-operators/lib-common/modules/common v0.6.1-0.20250508141203-be026d3164f7 h1:c3h1q3fDoit3NmvNL89xUL9A12bJivaTF+IOPEOAwLc=
 github.com/openstack-k8s-operators/lib-common/modules/common v0.6.1-0.20250508141203-be026d3164f7/go.mod h1:UwHXRIrMSPJD3lFqrA4oKmRXVLFQCRkLAj9x6KLEHiQ=
 github.com/openstack-k8s-operators/lib-common/modules/openstack v0.6.1-0.20250508141203-be026d3164f7 h1:IybBq3PrxwdvzAF19TjdMCqbEVkX2p3gIkme/Fju6do=

--- a/tests/functional/watcher_test_data.go
+++ b/tests/functional/watcher_test_data.go
@@ -30,38 +30,41 @@ type APIType string
 // WatcherTestData is the data structure used to provide input data to envTest
 type WatcherTestData struct {
 	//DatabaseHostname             string
-	DatabaseInstance                 string
-	RabbitMqClusterName              string
-	Instance                         types.NamespacedName
-	Watcher                          types.NamespacedName
-	WatcherDatabaseName              types.NamespacedName
-	WatcherDatabaseAccount           types.NamespacedName
-	WatcherDatabaseAccountSecret     types.NamespacedName
-	InternalTopLevelSecretName       types.NamespacedName
-	PrometheusSecretName             types.NamespacedName
-	WatcherTransportURL              types.NamespacedName
-	KeystoneServiceName              types.NamespacedName
-	WatcherAPI                       types.NamespacedName
-	MemcachedNamespace               types.NamespacedName
-	ServiceAccountName               types.NamespacedName
-	RoleName                         types.NamespacedName
-	RoleBindingName                  types.NamespacedName
-	WatcherDBSync                    types.NamespacedName
-	WatcherAPIStatefulSet            types.NamespacedName
-	WatcherDecisionEngine            types.NamespacedName
-	WatcherDecisionEngineStatefulSet types.NamespacedName
-	WatcherDecisionEngineSecret      types.NamespacedName
-	WatcherPublicServiceName         types.NamespacedName
-	WatcherInternalServiceName       types.NamespacedName
-	WatcherRouteName                 types.NamespacedName
-	WatcherInternalRouteName         types.NamespacedName
-	WatcherKeystoneEndpointName      types.NamespacedName
-	WatcherApplier                   types.NamespacedName
-	WatcherApplierStatefulSet        types.NamespacedName
-	WatcherRouteCertSecret           types.NamespacedName
-	WatcherPublicCertSecret          types.NamespacedName
-	WatcherInternalCertSecret        types.NamespacedName
-	WatcherApplierSecret             types.NamespacedName
+	DatabaseInstance                  string
+	RabbitMqClusterName               string
+	Instance                          types.NamespacedName
+	Watcher                           types.NamespacedName
+	WatcherDatabaseName               types.NamespacedName
+	WatcherDatabaseAccount            types.NamespacedName
+	WatcherDatabaseAccountSecret      types.NamespacedName
+	InternalTopLevelSecretName        types.NamespacedName
+	PrometheusSecretName              types.NamespacedName
+	WatcherTransportURL               types.NamespacedName
+	KeystoneServiceName               types.NamespacedName
+	WatcherAPI                        types.NamespacedName
+	WatcherAPIConfigSecret            types.NamespacedName
+	MemcachedNamespace                types.NamespacedName
+	ServiceAccountName                types.NamespacedName
+	RoleName                          types.NamespacedName
+	RoleBindingName                   types.NamespacedName
+	WatcherDBSync                     types.NamespacedName
+	WatcherAPIStatefulSet             types.NamespacedName
+	WatcherDecisionEngine             types.NamespacedName
+	WatcherDecisionEngineConfigSecret types.NamespacedName
+	WatcherDecisionEngineStatefulSet  types.NamespacedName
+	WatcherDecisionEngineSecret       types.NamespacedName
+	WatcherPublicServiceName          types.NamespacedName
+	WatcherInternalServiceName        types.NamespacedName
+	WatcherRouteName                  types.NamespacedName
+	WatcherInternalRouteName          types.NamespacedName
+	WatcherKeystoneEndpointName       types.NamespacedName
+	WatcherApplier                    types.NamespacedName
+	WatcherApplierConfigSecret        types.NamespacedName
+	WatcherApplierStatefulSet         types.NamespacedName
+	WatcherRouteCertSecret            types.NamespacedName
+	WatcherPublicCertSecret           types.NamespacedName
+	WatcherInternalCertSecret         types.NamespacedName
+	WatcherApplierSecret              types.NamespacedName
 }
 
 // GetWatcherTestData is a function that initialize the WatcherTestData
@@ -110,9 +113,17 @@ func GetWatcherTestData(watcherName types.NamespacedName) WatcherTestData {
 			Namespace: watcherName.Namespace,
 			Name:      "watcher-api",
 		},
+		WatcherAPIConfigSecret: types.NamespacedName{
+			Namespace: watcherName.Namespace,
+			Name:      "watcher-api-config-data",
+		},
 		WatcherDecisionEngine: types.NamespacedName{
 			Namespace: watcherName.Namespace,
 			Name:      "watcher-decision-engine",
+		},
+		WatcherDecisionEngineConfigSecret: types.NamespacedName{
+			Namespace: watcherName.Namespace,
+			Name:      "watcher-decision-engine-config-data",
 		},
 		WatcherDecisionEngineStatefulSet: types.NamespacedName{
 			Namespace: watcherName.Namespace,
@@ -169,6 +180,10 @@ func GetWatcherTestData(watcherName types.NamespacedName) WatcherTestData {
 		WatcherApplier: types.NamespacedName{
 			Namespace: watcherName.Namespace,
 			Name:      "watcher-applier",
+		},
+		WatcherApplierConfigSecret: types.NamespacedName{
+			Namespace: watcherName.Namespace,
+			Name:      "watcher-applier-config-data",
 		},
 		WatcherApplierStatefulSet: types.NamespacedName{
 			Namespace: watcherName.Namespace,

--- a/tests/functional/watcherapi_controller_test.go
+++ b/tests/functional/watcherapi_controller_test.go
@@ -114,6 +114,7 @@ var _ = Describe("WatcherAPI controller", func() {
 		})
 	})
 	When("the secret is created with all the expected fields and has all the required infra", func() {
+		var keystoneAPIName types.NamespacedName
 		BeforeEach(func() {
 			secret := th.CreateSecret(
 				watcherTest.InternalTopLevelSecretName,
@@ -162,7 +163,8 @@ var _ = Describe("WatcherAPI controller", func() {
 			mariadb.SimulateMariaDBAccountCompleted(watcherTest.WatcherDatabaseAccount)
 			mariadb.SimulateMariaDBDatabaseCompleted(watcherTest.WatcherDatabaseName)
 			DeferCleanup(th.DeleteInstance, CreateWatcherAPI(watcherTest.WatcherAPI, GetDefaultWatcherAPISpec()))
-			DeferCleanup(keystone.DeleteKeystoneAPI, keystone.CreateKeystoneAPI(watcherTest.WatcherAPI.Namespace))
+			keystoneAPIName = keystone.CreateKeystoneAPI(watcherTest.WatcherAPI.Namespace)
+			DeferCleanup(keystone.DeleteKeystoneAPI, keystoneAPIName)
 			memcachedSpec := memcachedv1.MemcachedSpec{
 				MemcachedSpecCore: memcachedv1.MemcachedSpecCore{
 					Replicas: ptr.To(int32(1)),
@@ -268,6 +270,29 @@ var _ = Describe("WatcherAPI controller", func() {
 
 			WatcherAPI := GetWatcherAPI(watcherTest.WatcherAPI)
 			Expect(WatcherAPI.IsReady()).Should(BeTrue())
+		})
+
+		It("updates the KeystoneAuthURL if keystone internal endpoint changes", func() {
+			newInternalEndpoint := "https://keystone-internal"
+
+			keystone.UpdateKeystoneAPIEndpoint(keystoneAPIName, "internal", newInternalEndpoint)
+			logger.Info("Reconfigured")
+
+			th.ExpectCondition(
+				watcherTest.WatcherAPI,
+				ConditionGetterFunc(WatcherAPIConditionGetter),
+				condition.ServiceConfigReadyCondition,
+				corev1.ConditionTrue,
+			)
+
+			Eventually(func(g Gomega) {
+				confSecret := th.GetSecret(watcherTest.WatcherAPIConfigSecret)
+				g.Expect(confSecret).ShouldNot(BeNil())
+
+				conf := string(confSecret.Data["00-default.conf"])
+				g.Expect(conf).Should(
+					ContainSubstring("auth_url = %s", newInternalEndpoint))
+			}, timeout, interval).Should(Succeed())
 		})
 	})
 	When("the secret is created but missing fields", func() {


### PR DESCRIPTION
Adds watches of the Nova controller on the KeystoneAPI status to reconcile if e.g. the endpoint list changes. This triggers setting the new KeystoneAuthURL on the sub components to update their configuration.

Depends-On: https://github.com/openstack-k8s-operators/keystone-operator/pull/591

Jira: OSPRH-16994