### PR TITLE
Install golang on controller before deploying watcher

### DIFF
--- a/ci/scenarios/edpm.yml
+++ b/ci/scenarios/edpm.yml
@@ -9,6 +9,11 @@ pre_deploy_create_coo_subscription:
     type: playbook
     source: "{{ watcher_coo_hook }}"
 post_deploy:
+  - name: Download needed tools
+    type: playbook
+    inventory: "/home/zuul/src/github.com/openstack-k8s-operators/install_yamls/devsetup/hosts"
+    source: "/home/zuul/src/github.com/openstack-k8s-operators/install_yamls/devsetup/download_tools.yaml"
+
   - name: Deploy watcher service
     type: playbook
     source: "{{ watcher_hook }}"


### PR DESCRIPTION
When we run make watcher_deploy on controller in uni jobs. It fails with 'make: go: No such file or directory'.

go was not installed on the controller leading to watcher service deploy failure.

Running make download_tools install golang and fixes the issue.

Signed-off-by: Chandan Kumar (raukadah) <raukadah@gmail.com>

Depends-On: https://github.com/openstack-k8s-operators/ci-framework/pull/3063

Jira: [OSPRH-12132](https://issues.redhat.com//browse/OSPRH-12132)