### PR TITLE
Make deployment jobs compatible with standalone and integrated mode

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -129,6 +129,7 @@
       deploy_watcher_service_extra_vars:
         watcher_catalog_image: "{{ cifmw_operator_build_output['operators']['watcher-operator'].image_catalog }}"
         deploy_watcher_service: false
+        force_watcher_standalone: true
       cifmw_extras:
         - "@{{ ansible_user_dir }}/{{ zuul.projects['github.com/openstack-k8s-operators/watcher-operator'].
            src_dir }}/ci/scenarios/kuttl.yml"
@@ -163,7 +164,6 @@
     pre-run:
       - ci/playbooks/copy_container_files.yaml
     vars:
-      cifmw_operator_build_meta_build: false
       cifmw_bop_openstack_release: epoxy
       cifmw_bop_dlrn_baseurl: "https://trunk.rdoproject.org/centos9-epoxy"
       cifmw_repo_setup_branch: epoxy
@@ -224,7 +224,6 @@
     parent: openstack-meta-content-provider
     vars:
       cifmw_bop_openstack_release: master
-      cifmw_operator_build_meta_build: false
       cifmw_bop_dlrn_baseurl: "https://trunk.rdoproject.org/centos10-master"
       cifmw_repo_setup_branch: master
       cifmw_build_containers_registry_namespace: podified-master-centos10

--- a/Makefile
+++ b/Makefile
@@ -397,8 +397,16 @@ OPENSTACK_NAMESPACE ?= openstack
 
 .PHONY: watcher_deploy
 watcher_deploy: ## Deploy watcher service
+	# In some cases, when we do not have the mutating webhooks enabled, we need to have images URLs
+	# in the watcher CR and get it replaced by the url of containers to be  tested
+	$(eval TEMPDIR=$(shell mktemp -d))
+	cp ${WATCHER_SAMPLE_CR_PATH} ${TEMPDIR}
+	sed -i "s|WATCHER_API_CI_IMAGE|${WATCHER_API_CI_IMAGE}|g" ${TEMPDIR}/*
+	sed -i "s|WATCHER_APPLIER_CI_IMAGE|${WATCHER_APPLIER_CI_IMAGE}|g" ${TEMPDIR}/*
+	sed -i "s|WATCHER_DECISION_ENGINE_CI_IMAGE|${WATCHER_DECISION_ENGINE_CI_IMAGE}|g" ${TEMPDIR}/*
 	oc apply -f ${WATCHER_SAMPLE_CR_PATH} -n ${OPENSTACK_NAMESPACE}
 	oc wait watcher watcher --for condition=Ready --timeout=600s -n ${OPENSTACK_NAMESPACE}
+	rm -rf ${TEMPDIR}
 
 .PHONY: watcher_deploy_cleanup
 watcher_deploy_cleanup: ## Undeploy watcher service
@@ -414,6 +422,10 @@ watcher_cleanup: ## Cleaning watcher operator via olm
 KUTTL_SUITE ?= default
 KUTTL_NAMESPACE ?= watcher-kuttl-$(KUTTL_SUITE)
 KUTTL_SUITE_DIR ?= tests/kuttl/test-suites/$(KUTTL_SUITE)
+
+.PHONY: stop_watcher_integrated
+stop_watcher_integrated:
+	bash hack/stop_integrated_watcher.sh
 
 .PHONY: kuttl-test-prep
 kuttl-test-prep:

--- a/ci/ctlplane_watcher_patch.yaml
+++ b/ci/ctlplane_watcher_patch.yaml
@@ -1,0 +1,9 @@
+spec:
+  watcher:
+    enabled: true
+    decisionengineServiceTemplate:
+      customServiceConfig: |
+        [watcher_cluster_data_model_collectors.compute]
+        period = 60
+        [watcher_cluster_data_model_collectors.storage]
+        period = 60

--- a/ci/full_watcher_v1beta1_watcher_tlse.yaml
+++ b/ci/full_watcher_v1beta1_watcher_tlse.yaml
@@ -1,0 +1,87 @@
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: watcher-internal-svc
+spec:
+  dnsNames:
+  - watcher-internal.openstack.svc
+  - watcher-internal.openstack.svc.cluster.local
+  duration: 43800h0m0s
+  issuerRef:
+    group: cert-manager.io
+    kind: Issuer
+    name: rootca-internal
+  secretName: cert-watcher-internal-svc
+  usages:
+  - key encipherment
+  - digital signature
+  - server auth
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: watcher-public-route
+spec:
+  dnsNames:
+  - watcher-public-openstack.apps-crc.testing
+  issuerRef:
+    group: cert-manager.io
+    kind: Issuer
+    name: rootca-public
+  secretName: cert-watcher-public-route
+  usages:
+  - key encipherment
+  - digital signature
+  - server auth
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: watcher-public-svc
+spec:
+  dnsNames:
+  - watcher-public.openstack.svc
+  - watcher-public.openstack.svc.cluster.local
+  duration: 43800h0m0s
+  issuerRef:
+    group: cert-manager.io
+    kind: Issuer
+    name: rootca-public
+  secretName: cert-watcher-public-svc
+  usages:
+  - key encipherment
+  - digital signature
+  - server auth
+---
+apiVersion: watcher.openstack.org/v1beta1
+kind: Watcher
+metadata:
+  name: watcher
+spec:
+  apiContainerImageURL: WATCHER_API_CI_IMAGE
+  applierContainerImageURL: WATCHER_APPLIER_CI_IMAGE
+  decisionengineContainerImageURL: WATCHER_DECISION_ENGINE_CI_IMAGE
+  dbPurge: {}
+  databaseInstance: "openstack"
+  apiOverride:
+    tls:
+      secretName: cert-watcher-public-route
+  apiServiceTemplate:
+    override:
+      service:
+        public:
+          endpointURL: https://watcher-public-openstack.apps-crc.testing
+    tls:
+      caBundleSecretName: "combined-ca-bundle"
+      api:
+        internal:
+          secretName: cert-watcher-internal-svc
+        public:
+          secretName: cert-watcher-public-svc
+  decisionengineServiceTemplate:
+    customServiceConfig: |
+      [watcher_cluster_data_model_collectors.compute]
+      period = 60
+      [watcher_cluster_data_model_collectors.storage]
+      period = 60

--- a/ci/playbooks/deploy_watcher_service.yaml
+++ b/ci/playbooks/deploy_watcher_service.yaml
@@ -4,10 +4,26 @@
 - name: Deploy Watcher service
   hosts: "{{ cifmw_target_hook_host | default('localhost') }}"
   gather_facts: false
+  vars:
+    watcher_cr_file_full: "ci/full_watcher_v1beta1_watcher_tlse.yaml"
   environment:
     KUBECONFIG: "{{ cifmw_openshift_kubeconfig }}"
     PATH: "{{ cifmw_path }}"
+    CTLPLANE_PATCH: "{{ watcher_ctlplane_patch | default( '{{ watcher_repo }}/ci/ctlplane_watcher_patch.yaml' ) }}"
   tasks:
+    # If the watcher-operator installation is already included in the openstack-operator we don't need to install it as
+    # an standalone operator.
+    - name: Check if Watcher API resources are available
+      ansible.builtin.shell:
+        cmd:
+          oc api-resources --api-group=watcher.openstack.org -o name | grep -q watcher
+      failed_when: false
+      register: watcher_api_resources
+
+    - name: add watcher_installed_integrated fact, true if Watcher API resources exist
+      set_fact:
+        watcher_installed_integrated: "{{ watcher_api_resources.rc == 0 }}"
+
     - name: Fetch dlrn md5_hash from DLRN repo
       when: fetch_dlrn_hash | default(true) | bool
       ansible.builtin.uri:
@@ -18,34 +34,111 @@
       retries: 6
       delay: 5
 
-    - name: Install Watcher Operator
-      vars:
-        _tag: "{{ latest_dlrn_tag.content | default(watcher_services_tag) | default('current-podified') }}"
-        # When there is no Depends-On from opendev, then content_provider_os_registry_url will return null
-        # value to child job. In that case, we need to set default to quay registry.
-        _registry_url: >-
-          {%- if watcher_registry_url is defined -%}
-          {{ watcher_registry_url }}
-          {%- elif content_provider_os_registry_url is defined and content_provider_os_registry_url == 'null' -%}
-          quay.io/podified-master-centos9
-          {%- else -%}
-          {{ content_provider_os_registry_url | default('quay.io/podified-master-centos9') }}
-          {%- endif -%}
-      cifmw.general.ci_script:
-        output_dir: "{{ cifmw_basedir }}/artifacts"
-        chdir: "{{ watcher_repo }}"
-        script: make watcher
-        extra_args:
-          CATALOG_IMAGE: "{{ watcher_catalog_image | default('quay.io/openstack-k8s-operators/watcher-operator-index:latest') }}"
-          WATCHER_API_CI_IMAGE: "{{ _registry_url }}/openstack-watcher-api:{{ _tag }}"
-          WATCHER_DECISION_ENGINE_CI_IMAGE: "{{ _registry_url }}/openstack-watcher-decision-engine:{{ _tag }}"
-          WATCHER_APPLIER_CI_IMAGE: "{{ _registry_url }}/openstack-watcher-applier:{{ _tag }}"
+    - name: Install standalone watcher-operator if not integrated or force_watcher_standalone is true
+      when: (not watcher_installed_integrated) or (force_watcher_standalone | default(false) | bool)
+      block:
+        - name: Stop watcher-operator if it is running in integrated mode
+          when: watcher_installed_integrated
+          cifmw.general.ci_script:
+            output_dir: "{{ cifmw_basedir }}/artifacts"
+            chdir: "{{ watcher_repo }}"
+            script: make stop_watcher_integrated
+
+        - name: Install Watcher Operator in standalone mode
+          vars:
+            _tag: "{{ latest_dlrn_tag.content | default(watcher_services_tag) | default('current-podified') }}"
+            # When there is no Depends-On from opendev, then content_provider_os_registry_url will return null
+            # value to child job. In that case, we need to set default to quay registry.
+            _registry_url: >-
+              {%- if watcher_registry_url is defined -%}
+              {{ watcher_registry_url }}
+              {%- elif content_provider_os_registry_url is defined and content_provider_os_registry_url == 'null' -%}
+              quay.io/podified-master-centos9
+              {%- else -%}
+              {{ content_provider_os_registry_url | default('quay.io/podified-master-centos9') }}
+              {%- endif -%}
+          cifmw.general.ci_script:
+            output_dir: "{{ cifmw_basedir }}/artifacts"
+            chdir: "{{ watcher_repo }}"
+            script: make watcher
+            extra_args:
+              CATALOG_IMAGE: "{{ watcher_catalog_image | default('quay.io/openstack-k8s-operators/watcher-operator-index:latest') }}"
+              WATCHER_API_CI_IMAGE: "{{ _registry_url }}/openstack-watcher-api:{{ _tag }}"
+              WATCHER_DECISION_ENGINE_CI_IMAGE: "{{ _registry_url }}/openstack-watcher-decision-engine:{{ _tag }}"
+              WATCHER_APPLIER_CI_IMAGE: "{{ _registry_url }}/openstack-watcher-applier:{{ _tag }}"
+
+    # Once the integration in the openstack controlplane is finished and merged everywhere we will be
+    # able to deploy watcher using kustomize in a pre_deploy hook. Until then we need to discover
+    # if the integration is finished and that can not be done in pre_deploy hook as it runs before
+    # make openstack_init so I am implementing it in this playbook which runs in post_deploy
+    - name: Check if a Watcher CR is already created
+      ansible.builtin.shell:
+        cmd:
+          oc get watcher -A -o name | grep -q watcher
+      failed_when: false
+      register: watcher_deployed
+
+    - name: Add watcher_is_deployed fact, true if a Watcher CR exist, otherwise false
+      set_fact:
+        watcher_is_deployed: "{{ watcher_deployed.rc == 0 }}"
+
+    - name: Check if Watcher is fully integrated in the OpenStackControlPlane
+      ansible.builtin.shell:
+        cmd:
+          oc explain openstackcontrolplane.spec|grep -q -w "watcher"
+      failed_when: false
+      register: watcher_controlplane_spec
+
+    - name: Add watcher_in_ctlplane fact, true if Watcher is in the controlplane CRD
+      set_fact:
+        watcher_in_ctlplane: "{{ watcher_controlplane_spec.rc == 0 }}"
 
     - name: Deploy Watcher service
-      when: deploy_watcher_service | default('true') | bool
-      cifmw.general.ci_script:
-        output_dir: "{{ cifmw_basedir }}/artifacts"
-        chdir: "{{ watcher_repo }}"
-        script: make watcher_deploy
-        extra_args:
-          WATCHER_SAMPLE_CR_PATH: "{{ watcher_cr_file | default('ci/watcher_v1beta1_watcher.yaml') }}"
+      when:
+        - deploy_watcher_service | default('true') | bool
+        - not watcher_is_deployed
+      block:
+        # When not using the standalone mode in the operator but watcher is not
+        # in the openstackcontrolplane we do not have mutating webhooks so we need
+        # to override the Watcher CR to use one that includes the container image URLs
+        - name: Set watcher_cr_file to the one with container images
+          when:
+            - not watcher_in_ctlplane
+            - watcher_installed_integrated
+            - not force_watcher_standalone | default(false) | bool
+          set_fact:
+             watcher_cr_file_override: "{{ watcher_cr_file_full }}"
+
+        - name: Deploy Watcher service using standalone Watcher CR
+          when: not watcher_in_ctlplane
+          vars:
+            _tag: "{{ latest_dlrn_tag.content | default(watcher_services_tag) | default('current-podified') }}"
+            # When there is no Depends-On from opendev, then content_provider_os_registry_url will return null
+            # value to child job. In that case, we need to set default to quay registry.
+            _registry_url: >-
+              {%- if watcher_registry_url is defined -%}
+              {{ watcher_registry_url }}
+              {%- elif content_provider_os_registry_url is defined and content_provider_os_registry_url == 'null' -%}
+              quay.io/podified-master-centos9
+              {%- else -%}
+              {{ content_provider_os_registry_url | default('quay.io/podified-master-centos9') }}
+              {%- endif -%}
+          cifmw.general.ci_script:
+            output_dir: "{{ cifmw_basedir }}/artifacts"
+            chdir: "{{ watcher_repo }}"
+            script: make watcher_deploy
+            extra_args:
+              WATCHER_SAMPLE_CR_PATH: "{{ watcher_cr_file_override | default( watcher_cr_file | default('ci/watcher_v1beta1_watcher.yaml')) }}"
+              WATCHER_API_CI_IMAGE: "{{ _registry_url }}/openstack-watcher-api:{{ _tag }}"
+              WATCHER_DECISION_ENGINE_CI_IMAGE: "{{ _registry_url }}/openstack-watcher-decision-engine:{{ _tag }}"
+              WATCHER_APPLIER_CI_IMAGE: "{{ _registry_url }}/openstack-watcher-applier:{{ _tag }}"
+
+        - name: Deploy Watcher service by patching an existing OpenStackControlplane
+          when: watcher_in_ctlplane
+          ansible.builtin.shell:
+            cmd: |
+              set -ex
+              CTLPLANE=$(oc get openstackcontrolplane -n openstack -o jsonpath="{range .items[*]}{@.metadata.name}{end}")
+              oc patch openstackcontrolplane $CTLPLANE -n openstack --type merge --patch-file $CTLPLANE_PATCH
+              oc wait openstackcontrolplane $CTLPLANE -n openstack --for condition=Ready --timeout=600s
+              oc wait watcher watcher -n openstack --for condition=Ready --timeout=600s

--- a/ci/scenarios/kuttl.yml
+++ b/ci/scenarios/kuttl.yml
@@ -22,3 +22,6 @@ post_install_operators_kuttl_from_operator:
         deploy_watcher_service_extra_vars | default({}) |
         combine({ 'watcher_repo': watcher_repo })
       }}
+
+# Enable observability operator
+cifmw_deploy_obs: true

--- a/hack/stop_integrated_watcher.sh
+++ b/hack/stop_integrated_watcher.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+set -x
+
+WATCHER_CSV_NAME="$(oc get csv -n openstack-operators -l operators.coreos.com/watcher-operator.openstack-operators -o name)"
+
+if [ -z ${WATCHER_CSV_NAME} ]; then
+    OPENSTACK_CSV_NAME="$(oc get csv -n openstack-operators -l operators.coreos.com/openstack-operator.openstack-operators -o name)"
+    if [ -n "{OPENSTACK_CSV_NAME}" ]; then
+        oc patch "${OPENSTACK_CSV_NAME}" -n openstack-operators --type=json -p="[{'op': 'replace', 'path': '/spec/install/spec/deployments/0/spec/replicas', 'value': 0}]"
+        oc scale --replicas=0 -n openstack-operators deploy/watcher-operator-controller-manager
+    else
+        echo "Openstack operator is not installed"
+    fi
+else
+    echo "Watcher operator installed in standalone mode"
+fi


### PR DESCRIPTION
We are working in integrating the watcher-operator in the openstack-operator following the same approach that other openstack services operators are doing.

To make the transition smooth, I am proposing to make the jobs compatible with both standalone and integrated mode by implementing following changes:

- Now, the content provider jobs should be rebuilding the watcher-operator and the openstack-operator. For the integration mode, that should make that, when the openstack-operator deployes the watcher-operator it will run using the patched version of it.
- I'm adding logic to find out if the watcher-operator is already deployed when running the deploy_watcher_service.yaml playbook. If the Watcher CRDs are already installed, it means the watcher operator has been installed by the openstack-operator and there is no need to install it standalone.
- I'm also adding logic to find out if the watcher is integrated in the openstackcontrolplane. If so, watcher is deployed by patching the existing openstackcontrolplane. Otherwise, it creates a Watcher CR as it is currently doing.

Note that, at some point we will be able to improve this approach by applying a kustomization to the controlplane in pre_deploy, but at that time is not possible to discover if the watcher is already integrated in the openstackcontrolplane CRD, so we can keep using this post_deployment approach until the integration is finished and propagated to all the branches and environments.

Jira: [OSPRH-16242](https://issues.redhat.com//browse/OSPRH-16242)
