### PR TITLE
[unijobs] Patch telemetry service

### DIFF
--- a/ci/files/configure_telemetry_for_watcher_service.yaml
+++ b/ci/files/configure_telemetry_for_watcher_service.yaml
@@ -1,0 +1,28 @@
+---
+apiVersion: core.openstack.org/v1beta1
+kind: OpenStackControlPlane
+metadata:
+  name: controlplane
+spec:
+  telemetry:
+    enabled: true
+    template:
+      ceilometer:
+        enabled: true
+      metricStorage:
+        enabled: true
+        customMonitoringStack:
+          alertmanagerConfig:
+            disabled: true
+          prometheusConfig:
+            enableRemoteWriteReceiver: true
+            persistentVolumeClaim:
+              resources:
+                requests:
+                  storage: 20G
+            replicas: 1
+            scrapeInterval: 30s
+          resourceSelector:
+            matchLabels:
+              service: metricStorage
+          retention: 24h

--- a/ci/files/remove-monitoring-stack-field.yaml
+++ b/ci/files/remove-monitoring-stack-field.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: core.openstack.org/v1beta1
+kind: OpenStackControlPlane
+metadata:
+  name: controlplane
+spec:
+  telemetry:
+    template:
+      metricStorage:
+        monitoringStack: null

--- a/ci/playbooks/deploy_watcher_service.yaml
+++ b/ci/playbooks/deploy_watcher_service.yaml
@@ -11,6 +11,23 @@
     PATH: "{{ cifmw_path }}"
     CTLPLANE_PATCH: "{{ watcher_ctlplane_patch | default( '{{ watcher_repo }}/ci/ctlplane_watcher_patch.yaml' ) }}"
   tasks:
+    - name: Configure telemetry for watcher service
+      when: deploy_watcher_service | default('true') | bool
+      block:
+        - name: Patch telemetry service to enable Remote Write Receiver
+          cifmw.general.ci_script:
+            output_dir: "{{ cifmw_basedir }}/artifacts"
+            chdir: "{{ watcher_repo }}/ci/files"
+            script: |
+              oc patch openstackcontrolplane controlplane --type='merge' --patch-file configure_telemetry_for_watcher_service.yaml -n openstack
+              oc patch openstackcontrolplane controlplane --type='merge' --patch-file remove-monitoring-stack-field.yaml -n openstack
+
+        - name: Wait for OpenStackControlPlane 'controlplane' to be redeployed
+          ansible.builtin.command:
+            cmd: >-
+              oc wait OpenStackControlPlane controlplane --namespace=openstack
+              --for=condition=Ready --timeout=10m
+
     # If the watcher-operator installation is already included in the openstack-operator we don't need to install it as
     # an standalone operator.
     - name: Check if Watcher API resources are available
@@ -23,7 +40,6 @@
     - name: add watcher_installed_integrated fact, true if Watcher API resources exist
       set_fact:
         watcher_installed_integrated: "{{ watcher_api_resources.rc == 0 }}"
-
     - name: Fetch dlrn md5_hash from DLRN repo
       when: fetch_dlrn_hash | default(true) | bool
       ansible.builtin.uri:

--- a/ci/scenarios/edpm.yml
+++ b/ci/scenarios/edpm.yml
@@ -23,49 +23,8 @@ post_deploy:
         combine({ 'watcher_repo': watcher_repo })
       }}
 
-# controlplane customization to deploy telemetry service
-# customMonitoringStack is used here to allow us to enable
-# enableRemoteWriteReceiver, needed when pushing fake metrics
-# to Prometheus server, via watcher-tempest-plugin.
 cifmw_edpm_prepare_timeout: 60
-cifmw_edpm_prepare_kustomizations:
-  - apiVersion: kustomize.config.k8s.io/v1beta1
-    kind: Kustomization
-    namespace: openstack
-    patches:
-    - patch: |-
-        apiVersion: core.openstack.org/v1beta1
-        kind: OpenStackControlPlane
-        metadata:
-          name: unused
-        spec:
-          telemetry:
-            enabled: true
-            template:
-              metricStorage:
-                enabled: true
-                customMonitoringStack:
-                  alertmanagerConfig:
-                    disabled: true
-                  prometheusConfig:
-                    replicas: 1
-                    enableRemoteWriteReceiver: true
-                    scrapeInterval: 30s
-                    persistentVolumeClaim:
-                      resources:
-                        requests:
-                          storage: 20G
-                  resourceSelector:
-                    matchLabels:
-                      service: metricStorage
-                  retention: 24h
-      target:
-        kind: OpenStackControlPlane
-    - patch: |-
-        - op: remove
-          path: /spec/telemetry/template/metricStorage/monitoringStack
-      target:
-        kind: OpenStackControlPlane
+
 cifmw_install_yamls_whitelisted_vars:
   - 'WATCHER_REPO'
   - 'WATCHER_BRANCH'


### PR DESCRIPTION
In uni03gamma job, telemetry is enabled but remotewritereceiver is not enabled. It is needed by watcher tempest plugin to push metrics using promtool over prometheus.

This pr adds the patch file to enable remotewritereceiver on the controlplane.

Assisted-By: Gemini 2.5 Flash

Jira: [OSPRH-12132](https://issues.redhat.com//browse/OSPRH-12132)