### PR TITLE
Enable Watcher storage collector by default

### DIFF
--- a/templates/00-default.conf
+++ b/templates/00-default.conf
@@ -112,3 +112,6 @@ period = 900
 
 [watcher_cluster_data_model_collectors.storage]
 period = 900
+
+[collector]
+collector_plugins = compute,storage


### PR DESCRIPTION
Enable both the compute and storage model collector by default in the
watcher-operator.
