### PR TITLE
Disable ceilometer_agent_compute and node_exporter in injected data jobs

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -63,6 +63,9 @@
       cifmw_test_operator_tempest_image_tag: current
       cifmw_test_operator_tempest_registry: "{{ cifmw_update_containers_registry }}"
       cifmw_test_operator_tempest_namespace: "{{ cifmw_update_containers_org }}"
+      cifmw_edpm_telemetry_enabled_exporters:
+        - podman_exporter
+        - openstack_network_exporter
 
 - job:
     name: watcher-operator-validation-base
@@ -80,6 +83,9 @@
       cifmw_update_containers_openstack: false
       deploy_watcher_service_extra_vars:
         watcher_catalog_image: "{{ cifmw_operator_build_output['operators']['watcher-operator'].image_catalog }}"
+      cifmw_edpm_telemetry_enabled_exporters:
+        - podman_exporter
+        - openstack_network_exporter
 
 - job:
     name: watcher-operator-validation


### PR DESCRIPTION
 Jobs with injected data are failing when we have metrics mixed from real exporters and injected ones.

This patch is adding a parameter to specify the list of enabled exporters which is provided by edpm_ansible [1] and configured via ci-framework [2].

This should fix the master job.

[1] https://github.com/openstack-k8s-operators/edpm-ansible/blob/fa813b904c6e70a28f0b86865fc190ccd2282ba6/roles/edpm_telemetry/defaults/main.yml#L56-L60
[2] https://github.com/openstack-k8s-operators/ci-framework/pull/3090/

Depends-On: https://review.opendev.org/c/openstack/watcher-tempest-plugin/+/953416
Depends-On: https://github.com/openstack-k8s-operators/watcher-operator/pull/202