### PR TITLE
Use current-tested in cs10 master watcher validation job

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -224,8 +224,8 @@
       fetch_dlrn_hash: false
       watcher_services_tag: watcher_latest
       watcher_registry_url: "{{ content_provider_os_registry_url }}"
-      cifmw_update_containers_tag: watcher_latest
-      cifmw_update_containers_registry: "{{ content_provider_os_registry_url  | split('/') | first }}"
+      cifmw_update_containers_tag: current-tested
+      cifmw_update_containers_registry: quay.rdoproject.org
       cifmw_test_operator_tempest_image_tag: watcher_latest
 
     extra-vars:


### PR DESCRIPTION
Depends-On: https://github.com/openstack-k8s-operators/watcher-operator/pull/202