### PR TITLE
Enable prometheus admin API to allow us to delete old injected metrics

### DIFF
--- a/ci/playbooks/deploy_watcher_service.yaml
+++ b/ci/playbooks/deploy_watcher_service.yaml
@@ -28,6 +28,16 @@
               oc wait OpenStackControlPlane controlplane --namespace=openstack
               --for=condition=Ready --timeout=10m
 
+        - name: Patch prometheuses.monitoring.rhobs metric-storage to enable Admin API
+          ansible.builtin.command:
+            cmd: >-
+              oc patch prometheuses.monitoring.rhobs metric-storage --namespace=openstack --type=merge -p '{"spec":{"enableAdminAPI":true}}'
+
+        - name: Wait for prometheuses.monitoring.rhobs metric-storage associated pod to be redeployed
+          ansible.builtin.command:
+            cmd: >-
+              oc wait pod prometheus-metric-storage-0 --for=condition=Ready -n openstack --timeout=10m
+
     # If the watcher-operator installation is already included in the openstack-operator we don't need to install it as
     # an standalone operator.
     - name: Check if Watcher API resources are available


### PR DESCRIPTION
We need to delete injected metrics between tests to avoid overlapping between tests

This can be done by enabling this API and executing requests like [1]

There is no option (by now) to do it on the openstackcontrolplane object, so now we have to patch prometheus after it is created, we will manage to add an option to include this API on the controlplane object [2]

[1] https://metric-storage-prometheus.openstack.svc:9090/api/v1/admin/tsdb/delete_series?match[]={job="promtool"}
[2] https://github.com/rhobs/observability-operator/blob/d0e25a27bde3ba2ca6c39a6fb259e93c8ae8cc99/pkg/apis/monitoring/v1alpha1/types.go#L177