### PR TITLE
Replace deprecated 'cifmw_test_operator_concurrency'

### DIFF
--- a/ci/tests/watcher-master.yml
+++ b/ci/tests/watcher-master.yml
@@ -21,7 +21,7 @@ cifmw_tempest_tempestconf_config:
     optimize.podified_namespace openstack
 
 run_tempest: false
-cifmw_test_operator_concurrency: 1
+cifmw_test_operator_tempest_concurrency: 1
 cifmw_test_operator_tempest_include_list: |
   watcher_tempest_plugin.*
 # Some strategies execution tests are failing. Excluding until the work on the watcher-tempest-plugin


### PR DESCRIPTION
Replace deprecated 'cifmw_test_operator_concurrency' with 'cifmw_test_operator_tempest_concurrency'
This aligns with the DoD described in https://issues.redhat.com/browse/OSPRH-16755