### PR TITLE
Enable NFS server as cinder backend for master job

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -235,7 +235,8 @@
     voting: false
     description: |
       A Zuul job consuming content from openstack-meta-content-provider-master
-      and deploying EDPM with master content.
+      and deploying EDPM with master content. It configures an NFS server in a
+      compute node as storage backend for cinder.
     vars:
       cifmw_repo_setup_branch: master
       # To consume containers from meta content provider
@@ -246,6 +247,19 @@
       watcher_services_tag: watcher_latest
       watcher_registry_url: "{{ content_provider_os_registry_url }}"
       cifmw_test_operator_tempest_image_tag: watcher_latest
+      cifmw_extras:
+        - "@{{ ansible_user_dir }}/{{ zuul.projects['github.com/openstack-k8s-operators/ci-framework'].
+           src_dir }}/scenarios/centos-9/multinode-ci.yml"
+        - "@{{ ansible_user_dir }}/{{ zuul.projects['github.com/openstack-k8s-operators/ci-framework'].
+           src_dir }}/scenarios/centos-9/horizon.yml"
+        - "@{{ ansible_user_dir }}/{{ zuul.projects['github.com/openstack-k8s-operators/watcher-operator'].
+           src_dir }}/ci/scenarios/edpm.yml"
+        - "@{{ ansible_user_dir }}/{{ zuul.projects['github.com/openstack-k8s-operators/watcher-operator'].
+           src_dir }}/ci/tests/watcher-tempest.yml"
+        - "@{{ ansible_user_dir }}/{{ zuul.projects['github.com/openstack-k8s-operators/watcher-operator'].
+           src_dir }}/ci/tests/watcher-tempest-nfs.yml"
+        - "@{{ ansible_user_dir }}/{{ zuul.projects['github.com/openstack-k8s-operators/watcher-operator'].
+           src_dir }}/ci/scenarios/nfs.yml"
 
     extra-vars:
       # Override zuul meta content provider provided content_provider_dlrn_md5_hash

--- a/ci/playbooks/cinder-nfs-enable.yaml
+++ b/ci/playbooks/cinder-nfs-enable.yaml
@@ -1,0 +1,100 @@
+---
+- name: Kustomize ControlPlane for cinder over NFS
+  hosts: "{{ cifmw_target_hook_host | default('localhost') }}"
+  gather_facts: false
+  vars:
+    cifmw_controlplane_kustomizations_path: "{{ cifmw_basedir }}/artifacts/manifests/kustomizations/controlplane"
+    _cinder_nfs_secret_files:
+      - cinder-volume-nfs-secrets.yaml
+      - cinder-volume-nfs-secrets-2.yaml
+  tasks:
+    - name: Ensure the kustomizations dir exists
+      ansible.builtin.file:
+        path: "{{ cifmw_controlplane_kustomizations_path }}"
+        state: directory
+
+    - name: Create the cinder-backup OpenStackControlPlane configuration file
+      ansible.builtin.copy:
+        dest: "{{ cifmw_controlplane_kustomizations_path }}/cinder-backup.yaml"
+        content: |
+          apiVersion: core.openstack.org/v1beta1
+          kind: OpenStackControlPlane
+          metadata:
+            name: openstack
+          spec:
+            cinder:
+              template:
+                cinderBackup:
+                  replicas: 1
+                  customServiceConfig: |
+                    [DEFAULT]
+                    backup_driver=cinder.backup.drivers.nfs.NFSBackupDriver
+                    backup_mount_options=nosharecache
+                  customServiceConfigSecrets:
+                    - cinder-backup-nfs-secrets
+                  networkAttachments:
+                  - storage
+
+    - name: Create the definition of the secrets for the cinder backup
+      ansible.builtin.template:
+        dest: "{{ cifmw_controlplane_kustomizations_path }}/cinder-backup-nfs-sercrets.yaml"
+        src: "cinder-backup-nfs-secrets.yaml.j2"
+        mode: '640'
+
+    - name: Create the definition of the secrets
+      vars:
+        share: "{{ cifmw_nfs_shares[indx] }}"
+        name: "{{ filename | splitext | first }}"
+      ansible.builtin.template:
+        dest: "{{ cifmw_controlplane_kustomizations_path }}/{{ filename }}"
+        src: "cinder-volume-nfs-secrets.yaml.j2"
+        mode: '640'
+      loop: "{{ _cinder_nfs_secret_files }}"
+      loop_control:
+        loop_var: filename
+        index_var: indx
+
+    - name: Apply the secrets
+      environment:
+        KUBECONFIG: "{{ cifmw_openshift_kubeconfig }}"
+        PATH: "{{ cifmw_path }}"
+      ansible.builtin.shell: |
+        oc project {{ namespace }}
+        oc apply -f {{ cifmw_controlplane_kustomizations_path }}/{{ item }}
+      register: apply_result
+      changed_when: ('stdout' in apply_result) and ('unchanged' not in apply_result.stdout)
+      failed_when: ( apply_result.rc | int ) > 1
+      loop: "{{ _cinder_nfs_secret_files + ['cinder-backup-nfs-sercrets.yaml'] }}"
+
+    - name: Create the nfs backend cinderVolume patch
+      ansible.builtin.template:
+        dest: "{{ cifmw_controlplane_kustomizations_path }}/nfs_backend.yaml"
+        src: "nfs_backend.yaml.j2"
+        mode: '640'
+
+    # FIXME: copy with inline content does not support templating, so this should be reworked
+    - name: Create kustomization to really enable NFS shares as backends for cinder and cinder-backup
+      ansible.builtin.copy:
+        dest: "{{ cifmw_controlplane_kustomizations_path }}/90-cinder-nfs.yaml"
+        content: |-
+          apiVersion: kustomize.config.k8s.io/v1beta1
+          kind: Kustomization
+          resources:
+          namespace: {{ namespace }}
+          # FIXME: patch the IP address of the NFS share using a better way to identify the exact volume
+          patches:
+          - target:
+              kind: OpenStackControlPlane
+              name: .*
+            patch: |-
+              - op: replace
+                path: /metadata/name
+                value: openstack
+          - target:
+              kind: OpenStackControlPlane
+              name: .*
+            patch: |-
+              - op: remove
+                path: /metadata/namespace
+          - path: {{ cifmw_controlplane_kustomizations_path + '/nfs_backend.yaml'}}
+          - path: {{ cifmw_controlplane_kustomizations_path + '/cinder-backup.yaml' }}

--- a/ci/playbooks/templates/cinder-backup-nfs-secrets.yaml.j2
+++ b/ci/playbooks/templates/cinder-backup-nfs-secrets.yaml.j2
@@ -1,0 +1,13 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  labels:
+    service: cinder
+    component: cinder-backup
+  name: cinder-backup-nfs-secrets
+type: Opaque
+stringData:
+  nfs-secrets.conf: |
+    [DEFAULT]
+    backup_share = {{ cifmw_nfs_ip }}:{{ '/data/' + cifmw_nfs_shares[-1] }}

--- a/ci/playbooks/templates/cinder-volume-nfs-secrets.yaml.j2
+++ b/ci/playbooks/templates/cinder-volume-nfs-secrets.yaml.j2
@@ -1,0 +1,14 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  labels:
+    service: cinder
+    component: cinder-volume
+  name: {{ name }}
+type: Opaque
+stringData:
+  {{ name }}: |
+    [nfs]
+    nas_host={{ cifmw_nfs_ip }}
+    nas_share_path={{ '/data/' + share }}

--- a/ci/playbooks/templates/nfs_backend.yaml.j2
+++ b/ci/playbooks/templates/nfs_backend.yaml.j2
@@ -1,0 +1,39 @@
+# Deploy a cinder NFS backend, with sensitive server settings (the nas_host
+# and nas_share_path) stored in the "cinder-volume-nfs-secrets" Secret.
+#
+# NOTE: Rather than using a shares-config file, the driver uses the nas_host
+# and nas_share_path parameters in the secrets file. For multiple shares,
+# configure a separate cinder-volume backend and secrets file for each share.
+
+apiVersion: core.openstack.org/v1beta1
+kind: OpenStackControlPlane
+metadata:
+  name: openstack
+spec:
+  cinder:
+    template:
+      cinderVolumes:
+        nfs:
+          networkAttachments:
+          - storage
+          customServiceConfig: |
+            [nfs]
+            volume_backend_name=nfs
+            volume_driver=cinder.volume.drivers.nfs.NfsDriver
+            nfs_snapshot_support=true
+            nas_secure_file_operations=false
+            nas_secure_file_permissions=false
+          customServiceConfigSecrets:
+          - cinder-volume-nfs-secrets
+        nfs-2:
+          networkAttachments:
+          - storage
+          customServiceConfig: |
+            [nfs]
+            volume_backend_name=nfs
+            volume_driver=cinder.volume.drivers.nfs.NfsDriver
+            nfs_snapshot_support=true
+            nas_secure_file_operations=false
+            nas_secure_file_permissions=false
+          customServiceConfigSecrets:
+          - cinder-volume-nfs-secrets-2

--- a/ci/scenarios/nfs.yml
+++ b/ci/scenarios/nfs.yml
@@ -1,0 +1,30 @@
+---
+watcher_repo: "{{ ansible_user_dir }}/src/github.com/openstack-k8s-operators/watcher-operator"
+cifmw_edpm_deploy_nfs: true
+cifmw_nfs_shares:
+  - cinder_backend_1
+  - cinder_backend_2
+  - cinderbackup
+
+cifmw_update_containers_cindervolumes:
+  - nfs
+  - nfs-2
+
+# NOTE(jgilaber): we might want to merge this file into scenarios/edpm.yml,
+# depending on how many jobs will have cinder volumes enabled
+ci_framework_base_src_dir: "{{ ansible_user_dir }}/{{ zuul.projects['github.com/openstack-k8s-operators/ci-framework'].src_dir }}"
+nfs_kustomize_hook: "{{ watcher_repo }}/ci/playbooks/cinder-nfs-enable.yaml"
+post_deploy:
+  - name: Download needed tools
+    type: playbook
+    inventory: "/home/zuul/src/github.com/openstack-k8s-operators/install_yamls/devsetup/hosts"
+    source: "/home/zuul/src/github.com/openstack-k8s-operators/install_yamls/devsetup/download_tools.yaml"
+  - name: Patch Openstack Prometheus to enable admin API
+    type: playbook
+    source: "{{ prometheus_admin_api_hook }}"
+  - name: 81 Kustomize Openstack CR to enable a Generic NFS-based backend
+    type: playbook
+    source: "{{ nfs_kustomize_hook }}"
+  - name: 82 Kustomize and update Control Plane
+    type: playbook
+    source: "{{ ci_framework_base_src_dir }}/hooks/playbooks/control_plane_kustomize_deploy.yml"

--- a/ci/tests/watcher-tempest-nfs.yml
+++ b/ci/tests/watcher-tempest-nfs.yml
@@ -1,0 +1,6 @@
+# get the tempest configuration from watcher-waster.yml, with the exception of
+# not skipping volume_migration tests
+cifmw_test_operator_tempest_exclude_list: |
+  watcher_tempest_plugin.*client_functional.*
+  watcher_tempest_plugin.tests.scenario.test_execute_strategies.TestExecuteStrategies.test_execute_storage_capacity_balance_strategy
+  watcher_tempest_plugin.*\[.*\breal_load\b.*\].*


### PR DESCRIPTION
Deploy an NFS server in a compute node using cifmw and use it as backend
for cinder. This is needed to test volume migrations and depending on
the result we might enable it in all jobs or only in some.

Depends-On: https://review.opendev.org/c/openstack/watcher-tempest-plugin/+/958644
Depends-On: https://github.com/openstack-k8s-operators/watcher-operator/pull/275