### PR TITLE
Change how the watcher hook waits for prometheus

### DIFF
--- a/ci/playbooks/deploy_watcher_service.yaml
+++ b/ci/playbooks/deploy_watcher_service.yaml
@@ -36,7 +36,8 @@
         - name: Wait for prometheuses.monitoring.rhobs metric-storage associated pod to be redeployed
           ansible.builtin.command:
             cmd: >-
-              oc wait pod prometheus-metric-storage-0 --for=condition=Ready -n openstack --timeout=10m
+              oc wait pod prometheus-metric-storage-0 --for=condition=Ready -n openstack --timeout=1m
+          retries: 10
 
     # If the watcher-operator installation is already included in the openstack-operator we don't need to install it as
     # an standalone operator.


### PR DESCRIPTION
Change how the watcher hook waits for the new prometheus-metric-storage
container after patching the metrie-storage service to enable admin api.
In some runs [1] the current method of waiting was calling oc wait in
between the time where openshift would delete the old container and
creating the new one, thus not waiting the specified timeout.

[1] https://softwarefactory-project.io/zuul/t/rdoproject.org/build/e058ff4467134a258e283c9da17e0192
