### PR TITLE
Use structured logging

### DIFF
--- a/controllers/watcher_controller.go
+++ b/controllers/watcher_controller.go
@@ -1233,7 +1233,7 @@ func (r *WatcherReconciler) SetupWithManager(mgr ctrl.Manager) error {
 func (r *WatcherReconciler) findObjectsForSrc(ctx context.Context, src client.Object) []reconcile.Request {
 	requests := []reconcile.Request{}
 
-	l := log.FromContext(ctx).WithName("Controllers").WithName("Watcher")
+	Log := r.GetLogger(ctx)
 
 	for _, field := range watcherWatchFields {
 		crList := &watcherv1beta1.WatcherList{}
@@ -1243,12 +1243,12 @@ func (r *WatcherReconciler) findObjectsForSrc(ctx context.Context, src client.Ob
 		}
 		err := r.Client.List(ctx, crList, listOps)
 		if err != nil {
-			l.Error(err, fmt.Sprintf("listing %s for field: %s - %s", crList.GroupVersionKind().Kind, field, src.GetNamespace()))
+			Log.Error(err, fmt.Sprintf("listing %s for field: %s - %s", crList.GroupVersionKind().Kind, field, src.GetNamespace()))
 			return requests
 		}
 
 		for _, item := range crList.Items {
-			l.Info(fmt.Sprintf("input source %s changed, reconcile: %s - %s", src.GetName(), item.GetName(), item.GetNamespace()))
+			Log.Info(fmt.Sprintf("input source %s changed, reconcile: %s - %s", src.GetName(), item.GetName(), item.GetNamespace()))
 
 			requests = append(requests,
 				reconcile.Request{

--- a/controllers/watcherapi_controller.go
+++ b/controllers/watcherapi_controller.go
@@ -925,7 +925,7 @@ func (r *WatcherAPIReconciler) SetupWithManager(mgr ctrl.Manager) error {
 func (r *WatcherAPIReconciler) findObjectsForSrc(ctx context.Context, src client.Object) []reconcile.Request {
 	requests := []reconcile.Request{}
 
-	l := log.FromContext(ctx).WithName("Controllers").WithName("WatcherAPI")
+	Log := r.GetLogger(ctx)
 
 	for _, field := range apiWatchFields {
 		crList := &watcherv1beta1.WatcherAPIList{}
@@ -935,12 +935,12 @@ func (r *WatcherAPIReconciler) findObjectsForSrc(ctx context.Context, src client
 		}
 		err := r.Client.List(ctx, crList, listOps)
 		if err != nil {
-			l.Error(err, fmt.Sprintf("listing %s for field: %s - %s", crList.GroupVersionKind().Kind, field, src.GetNamespace()))
+			Log.Error(err, fmt.Sprintf("listing %s for field: %s - %s", crList.GroupVersionKind().Kind, field, src.GetNamespace()))
 			return requests
 		}
 
 		for _, item := range crList.Items {
-			l.Info(fmt.Sprintf("input source %s changed, reconcile: %s - %s", src.GetName(), item.GetName(), item.GetNamespace()))
+			Log.Info(fmt.Sprintf("input source %s changed, reconcile: %s - %s", src.GetName(), item.GetName(), item.GetNamespace()))
 
 			requests = append(requests,
 				reconcile.Request{
@@ -959,7 +959,7 @@ func (r *WatcherAPIReconciler) findObjectsForSrc(ctx context.Context, src client
 func (r *WatcherAPIReconciler) findObjectForSrc(ctx context.Context, src client.Object) []reconcile.Request {
 	requests := []reconcile.Request{}
 
-	l := log.FromContext(ctx).WithName("Controllers").WithName("WatcherAPI")
+	Log := r.GetLogger(ctx)
 
 	crList := &watcherv1beta1.WatcherAPIList{}
 	listOps := &client.ListOptions{
@@ -967,12 +967,12 @@ func (r *WatcherAPIReconciler) findObjectForSrc(ctx context.Context, src client.
 	}
 	err := r.Client.List(ctx, crList, listOps)
 	if err != nil {
-		l.Error(err, fmt.Sprintf("listing %s for namespace: %s", crList.GroupVersionKind().Kind, src.GetNamespace()))
+		Log.Error(err, fmt.Sprintf("listing %s for namespace: %s", crList.GroupVersionKind().Kind, src.GetNamespace()))
 		return requests
 	}
 
 	for _, item := range crList.Items {
-		l.Info(fmt.Sprintf("input source %s changed, reconcile: %s - %s", src.GetName(), item.GetName(), item.GetNamespace()))
+		Log.Info(fmt.Sprintf("input source %s changed, reconcile: %s - %s", src.GetName(), item.GetName(), item.GetNamespace()))
 
 		requests = append(requests,
 			reconcile.Request{

--- a/controllers/watcherapplier_controller.go
+++ b/controllers/watcherapplier_controller.go
@@ -502,7 +502,7 @@ func (r *WatcherApplierReconciler) SetupWithManager(mgr ctrl.Manager) error {
 func (r *WatcherApplierReconciler) findObjectsForSrc(ctx context.Context, src client.Object) []reconcile.Request {
 	requests := []reconcile.Request{}
 
-	l := log.FromContext(ctx).WithName("Controllers").WithName("WatcherApplier")
+	Log := r.GetLogger(ctx)
 
 	for _, field := range applierWatchFields {
 		crList := &watcherv1beta1.WatcherApplierList{}
@@ -512,12 +512,12 @@ func (r *WatcherApplierReconciler) findObjectsForSrc(ctx context.Context, src cl
 		}
 		err := r.Client.List(ctx, crList, listOps)
 		if err != nil {
-			l.Error(err, fmt.Sprintf("listing %s for field: %s - %s", crList.GroupVersionKind().Kind, field, src.GetNamespace()))
+			Log.Error(err, fmt.Sprintf("listing %s for field: %s - %s", crList.GroupVersionKind().Kind, field, src.GetNamespace()))
 			return requests
 		}
 
 		for _, item := range crList.Items {
-			l.Info(fmt.Sprintf("input source %s changed, reconcile: %s - %s", src.GetName(), item.GetName(), item.GetNamespace()))
+			Log.Info(fmt.Sprintf("input source %s changed, reconcile: %s - %s", src.GetName(), item.GetName(), item.GetNamespace()))
 
 			requests = append(requests,
 				reconcile.Request{
@@ -536,7 +536,7 @@ func (r *WatcherApplierReconciler) findObjectsForSrc(ctx context.Context, src cl
 func (r *WatcherApplierReconciler) findObjectForSrc(ctx context.Context, src client.Object) []reconcile.Request {
 	requests := []reconcile.Request{}
 
-	l := log.FromContext(ctx).WithName("Controllers").WithName("WatcherApplier")
+	Log := r.GetLogger(ctx)
 
 	crList := &watcherv1beta1.WatcherApplierList{}
 	listOps := &client.ListOptions{
@@ -544,12 +544,12 @@ func (r *WatcherApplierReconciler) findObjectForSrc(ctx context.Context, src cli
 	}
 	err := r.Client.List(ctx, crList, listOps)
 	if err != nil {
-		l.Error(err, fmt.Sprintf("listing %s for namespace: %s", crList.GroupVersionKind().Kind, src.GetNamespace()))
+		Log.Error(err, fmt.Sprintf("listing %s for namespace: %s", crList.GroupVersionKind().Kind, src.GetNamespace()))
 		return requests
 	}
 
 	for _, item := range crList.Items {
-		l.Info(fmt.Sprintf("input source %s changed, reconcile: %s - %s", src.GetName(), item.GetName(), item.GetNamespace()))
+		Log.Info(fmt.Sprintf("input source %s changed, reconcile: %s - %s", src.GetName(), item.GetName(), item.GetNamespace()))
 
 		requests = append(requests,
 			reconcile.Request{

--- a/controllers/watcherdecisionengine_controller.go
+++ b/controllers/watcherdecisionengine_controller.go
@@ -393,7 +393,7 @@ func (r *WatcherDecisionEngineReconciler) SetupWithManager(mgr ctrl.Manager) err
 func (r *WatcherDecisionEngineReconciler) findObjectsForSrc(ctx context.Context, src client.Object) []reconcile.Request {
 	requests := []reconcile.Request{}
 
-	l := log.FromContext(ctx).WithName("Controllers").WithName("WatcherDecisionEngine")
+	Log := r.GetLogger(ctx)
 
 	for _, field := range decisionEngineWatchFields {
 		crList := &watcherv1beta1.WatcherDecisionEngineList{}
@@ -403,12 +403,12 @@ func (r *WatcherDecisionEngineReconciler) findObjectsForSrc(ctx context.Context,
 		}
 		err := r.Client.List(ctx, crList, listOps)
 		if err != nil {
-			l.Error(err, fmt.Sprintf("listing %s for field: %s - %s", crList.GroupVersionKind().Kind, field, src.GetNamespace()))
+			Log.Error(err, fmt.Sprintf("listing %s for field: %s - %s", crList.GroupVersionKind().Kind, field, src.GetNamespace()))
 			return requests
 		}
 
 		for _, item := range crList.Items {
-			l.Info(fmt.Sprintf("input source %s changed, reconcile: %s - %s", src.GetName(), item.GetName(), item.GetNamespace()))
+			Log.Info(fmt.Sprintf("input source %s changed, reconcile: %s - %s", src.GetName(), item.GetName(), item.GetNamespace()))
 
 			requests = append(requests,
 				reconcile.Request{
@@ -427,7 +427,7 @@ func (r *WatcherDecisionEngineReconciler) findObjectsForSrc(ctx context.Context,
 func (r *WatcherDecisionEngineReconciler) findObjectForSrc(ctx context.Context, src client.Object) []reconcile.Request {
 	requests := []reconcile.Request{}
 
-	l := log.FromContext(ctx).WithName("Controllers").WithName("WatcherDecisionEngine")
+	Log := r.GetLogger(ctx)
 
 	crList := &watcherv1beta1.WatcherDecisionEngineList{}
 	listOps := &client.ListOptions{
@@ -435,12 +435,12 @@ func (r *WatcherDecisionEngineReconciler) findObjectForSrc(ctx context.Context, 
 	}
 	err := r.Client.List(ctx, crList, listOps)
 	if err != nil {
-		l.Error(err, fmt.Sprintf("listing %s for namespace: %s", crList.GroupVersionKind().Kind, src.GetNamespace()))
+		Log.Error(err, fmt.Sprintf("listing %s for namespace: %s", crList.GroupVersionKind().Kind, src.GetNamespace()))
 		return requests
 	}
 
 	for _, item := range crList.Items {
-		l.Info(fmt.Sprintf("input source %s changed, reconcile: %s - %s", src.GetName(), item.GetName(), item.GetNamespace()))
+		Log.Info(fmt.Sprintf("input source %s changed, reconcile: %s - %s", src.GetName(), item.GetName(), item.GetNamespace()))
 
 		requests = append(requests,
 			reconcile.Request{


### PR DESCRIPTION
This change uses GetLogger instead of direct use of log.FromContext to support structured logging.