### PR TITLE
Configure min and max microversion for watcher-tempest-plugin

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -27,7 +27,7 @@
         - "@{{ ansible_user_dir }}/{{ zuul.projects['github.com/openstack-k8s-operators/watcher-operator'].
            src_dir }}/ci/scenarios/edpm.yml"
         - "@{{ ansible_user_dir }}/{{ zuul.projects['github.com/openstack-k8s-operators/watcher-operator'].
-           src_dir }}/ci/tests/watcher-master.yml"
+           src_dir }}/ci/tests/watcher-tempest.yml"
 
 - job:
     name: periodic-watcher-operator-validation-master
@@ -51,7 +51,7 @@
         - "@{{ ansible_user_dir }}/{{ zuul.projects['github.com/openstack-k8s-operators/watcher-operator'].
            src_dir }}/ci/scenarios/edpm.yml"
         - "@{{ ansible_user_dir }}/{{ zuul.projects['github.com/openstack-k8s-operators/watcher-operator'].
-           src_dir }}/ci/tests/watcher-master.yml"
+           src_dir }}/ci/tests/watcher-tempest.yml"
       fetch_dlrn_hash: false
       # Note(chandankumar): It tests cs10 master container current tag build from
       # DLRN current.
@@ -174,6 +174,8 @@
       cifmw_test_operator_tempest_registry: "{{ content_provider_os_registry_url | split('/') | first }}"
       cifmw_test_operator_tempest_namespace: "{{ content_provider_os_registry_url | split('/') | last }}"
       cifmw_test_operator_tempest_image_tag: watcher_latest
+      # Max api microversion for epoxy release
+      watcher_tempest_max_microversion: "1.4"
 
 - job:
     name: watcher-operator-validation-epoxy-ocp4-16

--- a/ci/tests/watcher-tempest.yml
+++ b/ci/tests/watcher-tempest.yml
@@ -10,6 +10,8 @@ cifmw_tempest_tempestconf_config:
     telemetry_services.metric_backends prometheus
     telemetry.disable_ssl_certificate_validation true
     telemetry.ceilometer_polling_interval 15
+    optimize.min_microversion {{ watcher_tempest_min_microversion | default('1.0') }}
+    optimize.max_microversion {{ watcher_tempest_max_microversion | default('latest') }}
     optimize.datasource prometheus
     optimize.openstack_type podified
     optimize.proxy_host_address {{ hostvars['controller']['ansible_host'] }}


### PR DESCRIPTION
A new upstream patch is adding microversion testing for watcher-tempest-plugin, and it will be mandatory to configure the min and max microversion to be tested in each job. To make the opendev job to work with new microversions, we can set max_microversion to 'latest' and for stable branches jobs we override with the latest microversion for each release. This PR also sets 1.4 as max microversion for Epoxy. It also renames the test configuration file to replaces the suffix master since this file is being used in all jobs.

Depends-On: https://review.opendev.org/c/openstack/watcher-tempest-plugin/+/956306