### PR TITLE
Bump watcher-tempest-plugin for epoxy jobs to known good commit

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -176,6 +176,11 @@
       cifmw_test_operator_tempest_image_tag: watcher_latest
       # Max api microversion for epoxy release
       watcher_tempest_max_microversion: "1.4"
+      # Use watcher-tempest-plugin from known-compatible commit to current status of epoxy branch
+      cifmw_test_operator_tempest_external_plugin:
+        - repository: "https://opendev.org/openstack/watcher-tempest-plugin.git"
+          changeRepository: "https://review.opendev.org/openstack/watcher-tempest-plugin"
+          changeRefspec: "380572db57798530b64dcac14c6b01b0382c5d8e"
 
 - job:
     name: watcher-operator-validation-epoxy-ocp4-16

--- a/ci/tests/watcher-tempest.yml
+++ b/ci/tests/watcher-tempest.yml
@@ -30,10 +30,13 @@ cifmw_test_operator_tempest_include_list: |
 # is finished upstream.
 # TODO(chandankumar): Drop watcher_tempest_plugin.*client_functional.* from here and also remove it
 # from watcher-tempest-plugin by openstack release 2024.2 eol.
+# TODO(amoralej): Disable test_execute_zone_migration_without_destination_host until
+# https://review.opendev.org/c/openstack/watcher/+/951535 is merged
 cifmw_test_operator_tempest_exclude_list: |
   watcher_tempest_plugin.*client_functional.*
   watcher_tempest_plugin.tests.scenario.test_execute_strategies.TestExecuteStrategies.test_execute_storage_capacity_balance_strategy
   watcher_tempest_plugin.*\[.*\breal_load\b.*\].*
+  watcher_tempest_plugin.tests.scenario.test_execute_zone_migration.TestExecuteZoneMigrationStrategy.test_execute_zone_migration_without_destination_host
 
 # Tempest images cases
 # content_provider_os_registry_url is not null, It means an opendev depends-on is used


### PR DESCRIPTION
Currently, watcher-tempest-plugin is pinned in RDO to tag 3.4.0 [1].

Some fixes and improvements have been merged since then and the required backports in the watcher epoxy branch are merged, so let's bump the tempest plugin.

Given that in the past it has been usual that patches in master branch of the plugin requires backports in the watcher epoxy branch, I am not proposing to follow the master branch of the plugin but using a known good commit.

[1] https://github.com/redhat-openstack/rdoinfo/blob/ee923461f857154321314796ed06c8365c1457d0/tags/epoxy.yml#L943-L946