### PR TITLE
Set image_base in cifmw_operator_build_operators for meta operator

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -218,6 +218,7 @@
           src: "{{ ansible_user_dir }}/src/github.com/openstack-k8s-operators/watcher-operator"
         - name: openstack-operator
           src: "{{ ansible_user_dir }}/src/github.com/openstack-k8s-operators/openstack-operator"
+          image_base: watcher
 - job:
     name: watcher-operator-validation-master
     parent: watcher-operator-validation-base
@@ -313,6 +314,7 @@
                   src: "{{ ansible_user_dir }}/src/github.com/openstack-k8s-operators/watcher-operator"
                 - name: openstack-operator
                   src: "{{ ansible_user_dir }}/src/github.com/openstack-k8s-operators/openstack-operator"
+                  image_base: watcher
         - watcher-operator-validation-master:
             branches: master
             override-checkout: main


### PR DESCRIPTION
image_base is used to specify the operator project name. It is used openstack operator to include watcher operator catalog image into the openstack-operator catalog image.

Sometimes image_base is set to empty when there is no github operator depends-on. This pr sets the same in cifmw_operator_build_operators var.

The same is already added in telemetry-operator[1].

Links:
[1]. https://github.com/openstack-k8s-operators/telemetry-operator/pull/724