### PR TITLE
Set zuul_log_collection to false to trigger must-gather facts

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -85,6 +85,7 @@
       cifmw_edpm_telemetry_enabled_exporters:
         - podman_exporter
         - openstack_network_exporter
+      zuul_log_collection: false
 
 - job:
     name: watcher-operator-kuttl
@@ -102,6 +103,7 @@
       cifmw_extras:
         - "@{{ ansible_user_dir }}/{{ zuul.projects['github.com/openstack-k8s-operators/watcher-operator'].
            src_dir }}/ci/scenarios/kuttl.yml"
+      zuul_log_collection: false
     extra-vars:
       # Override zuul meta content provider provided content_provider_dlrn_md5_hash
       # var. As returned dlrn md5 hash comes from master release but job is using


### PR DESCRIPTION
Before moving to role, when the 99-logs.yml playbook was executed, the
variables was not set to, so it pick default value which is false, so
the playbook was executed. Now when it is in `cifmw_setup` role in
`run_logs.yml` task file, the condition is possitive, so it is skipped.

Add 'zuul_log_collection' var to overwrite other existing vars and
trigger gather facts.

Depends-On: https://github.com/openstack-k8s-operators/ci-framework/pull/3208
Depends-On: https://github.com/openstack-k8s-operators/ci-framework/pull/3231