### PR TITLE
Use the correct service type for watcher service

### DIFF
--- a/pkg/watcher/constants.go
+++ b/pkg/watcher/constants.go
@@ -5,7 +5,7 @@ const (
 	ServiceName = "watcher"
 
 	// ServiceType - Type of Watcher keystone service
-	ServiceType = "infra-optim"
+	ServiceType = "resource-optimization"
 
 	// DatabaseName - Name of the database used in CREATE DATABASE statement
 	DatabaseName = "watcher"

--- a/tests/kuttl/test-suites/default/watcher-api-scaling/01-assert.yaml
+++ b/tests/kuttl/test-suites/default/watcher-api-scaling/01-assert.yaml
@@ -168,7 +168,7 @@ spec:
   secret: osp-secret
   serviceDescription: Watcher Service
   serviceName: watcher
-  serviceType: infra-optim
+  serviceType: resource-optimization
   serviceUser: watcher
 ---
 apiVersion: v1

--- a/tests/kuttl/test-suites/default/watcher-notification/01-assert.yaml
+++ b/tests/kuttl/test-suites/default/watcher-notification/01-assert.yaml
@@ -174,7 +174,7 @@ spec:
   secret: osp-secret
   serviceDescription: Watcher Service
   serviceName: watcher
-  serviceType: infra-optim
+  serviceType: resource-optimization
   serviceUser: watcher
 ---
 apiVersion: batch/v1

--- a/tests/kuttl/test-suites/default/watcher-tls-certs-change/01-assert.yaml
+++ b/tests/kuttl/test-suites/default/watcher-tls-certs-change/01-assert.yaml
@@ -176,7 +176,7 @@ spec:
   secret: osp-secret
   serviceDescription: Watcher Service
   serviceName: watcher
-  serviceType: infra-optim
+  serviceType: resource-optimization
   serviceUser: watcher
 ---
 apiVersion: v1

--- a/tests/kuttl/test-suites/default/watcher-tls/01-assert.yaml
+++ b/tests/kuttl/test-suites/default/watcher-tls/01-assert.yaml
@@ -176,7 +176,7 @@ spec:
   secret: osp-secret
   serviceDescription: Watcher Service
   serviceName: watcher
-  serviceType: infra-optim
+  serviceType: resource-optimization
   serviceUser: watcher
 ---
 apiVersion: v1
@@ -491,7 +491,7 @@ commands:
       [ "$(oc get -n ${NAMESPACE} secret watcher-kuttl-api-config-data -o jsonpath='{.data.my\.cnf}'|base64 -d|grep -c 'ssl=1')" == 1 ]
       [ "$(oc get -n ${NAMESPACE} secret watcher-kuttl-api-config-data -o jsonpath='{.data.00-default\.conf}'|base64 -d|grep -c 'cafile = /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem')" == 2 ]
       # check that both endpoints have https set
-      oc exec -n ${NAMESPACE} openstackclient -- openstack endpoint list | grep infra-optim | [ $(grep -c https) == 2 ]
+      oc exec -n ${NAMESPACE} openstackclient -- openstack endpoint list | grep resource-optimization | [ $(grep -c https) == 2 ]
       # If we are running the container locally, skip following test
       if [ "$(oc get pods -n openstack-operators -o name -l openstack.org/operator-name=watcher)" == "" ]; then
           exit 0

--- a/tests/kuttl/test-suites/default/watcher-tls/02-assert.yaml
+++ b/tests/kuttl/test-suites/default/watcher-tls/02-assert.yaml
@@ -227,9 +227,9 @@ commands:
       [ $(oc get -n ${NAMESPACE} keystoneservice watcher -o jsonpath={.status.serviceID}) == ${SERVICEID} ]
       [ -n "$(oc get -n ${NAMESPACE} watcher watcher-kuttl -o jsonpath={.status.hash.dbsync})" ]
       # check that watcher internal endpoint does not use https
-      oc exec -n ${NAMESPACE} openstackclient -- openstack endpoint list | grep infra-optim | grep internal  | [ $(grep -c https) == 0 ]
+      oc exec -n ${NAMESPACE} openstackclient -- openstack endpoint list | grep resource-optimization | grep internal  | [ $(grep -c https) == 0 ]
       # check that watcher public endpoint does use https
-      oc exec -n ${NAMESPACE} openstackclient -- openstack endpoint list | grep infra-optim | grep public  | [ $(grep -c https) == 1 ]
+      oc exec -n ${NAMESPACE} openstackclient -- openstack endpoint list | grep resource-optimization | grep public  | [ $(grep -c https) == 1 ]
       # If we are running the container locally, skip following test
       if [ "$(oc get pods -n openstack-operators -o name -l openstack.org/operator-name=watcher)" == "" ]; then
           exit 0

--- a/tests/kuttl/test-suites/default/watcher-tls/03-assert.yaml
+++ b/tests/kuttl/test-suites/default/watcher-tls/03-assert.yaml
@@ -154,7 +154,7 @@ spec:
   secret: osp-secret
   serviceDescription: Watcher Service
   serviceName: watcher
-  serviceType: infra-optim
+  serviceType: resource-optimization
   serviceUser: watcher
 ---
 apiVersion: v1

--- a/tests/kuttl/test-suites/default/watcher-tls/04-assert.yaml
+++ b/tests/kuttl/test-suites/default/watcher-tls/04-assert.yaml
@@ -245,4 +245,4 @@ commands:
         echo "Success: ${counter} _URL_DEFAULT variables found."
       fi
       # check that no watcher endpoint uses https
-      oc exec -n ${NAMESPACE} openstackclient -- openstack endpoint list | grep infra-optim | [ $(grep -c https) == 0 ]
+      oc exec -n ${NAMESPACE} openstackclient -- openstack endpoint list | grep resource-optimization | [ $(grep -c https) == 0 ]

--- a/tests/kuttl/test-suites/default/watcher/01-assert.yaml
+++ b/tests/kuttl/test-suites/default/watcher/01-assert.yaml
@@ -180,7 +180,7 @@ spec:
   secret: osp-secret
   serviceDescription: Watcher Service
   serviceName: watcher
-  serviceType: infra-optim
+  serviceType: resource-optimization
   serviceUser: watcher
 ---
 apiVersion: v1

--- a/tests/kuttl/test-suites/default/watcher/04-assert.yaml
+++ b/tests/kuttl/test-suites/default/watcher/04-assert.yaml
@@ -176,7 +176,7 @@ spec:
   secret: osp-secret
   serviceDescription: Watcher Service
   serviceName: watcher
-  serviceType: infra-optim
+  serviceType: resource-optimization
   serviceUser: watcher
 ---
 apiVersion: batch/v1


### PR DESCRIPTION
The service-types-authority repo lists 'resource-optimization' as the
correct name for the watcher keystone service[1], while infra-optim is an
old alias. This change aligns the watcher deployments with the expected
type.

[1] https://opendev.org/openstack/service-types-authority/src/branch/master/service-types.yaml#L37
