### PR TITLE
Skip volume_migration to avoid failures in check

### DIFF
--- a/ci/tests/watcher-tempest.yml
+++ b/ci/tests/watcher-tempest.yml
@@ -32,12 +32,14 @@ cifmw_test_operator_tempest_include_list: |
 # from watcher-tempest-plugin by openstack release 2024.2 eol.
 # TODO(amoralej): Disable test_execute_zone_migration_without_destination_host until
 # https://review.opendev.org/c/openstack/watcher/+/951535 is merged
+# TODO(jgilaber): Disable volume_migration tests until we have support for
+# cinder notifications
 cifmw_test_operator_tempest_exclude_list: |
   watcher_tempest_plugin.*client_functional.*
   watcher_tempest_plugin.tests.scenario.test_execute_strategies.TestExecuteStrategies.test_execute_storage_capacity_balance_strategy
   watcher_tempest_plugin.*\[.*\breal_load\b.*\].*
   watcher_tempest_plugin.tests.scenario.test_execute_zone_migration.TestExecuteZoneMigrationStrategy.test_execute_zone_migration_without_destination_host
-
+  watcher_tempest_plugin.*\[.*\bvolume_migration\b.*\].*
 # Tempest images cases
 # content_provider_os_registry_url is not null, It means an opendev depends-on is used
 # in the change. In this case, tempest image url should be content_provider_os_registry_url


### PR DESCRIPTION
Patch [1] adds tests for volume migrations using the zone migration
strategy. The test can't configure a wait until the storage model is
updated and thus often fails because it's missing some volume as shown
in [2]. Until we have Cinder notifications enabled, which solves the
problem upstream, skip the test so it does not run and thus unblocks
merging the upstream tempest-plugin patch.

[1] https://review.opendev.org/c/openstack/watcher-tempest-plugin/+/954625
[2] https://github.com/openstack-k8s-operators/watcher-operator/pull/217
