### PR TITLE
[18.0-fr3] Add valid-subscription annotation to CSV

### DIFF
--- a/config/manifests/bases/watcher-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/watcher-operator.clusterserviceversion.yaml
@@ -12,6 +12,8 @@ metadata:
     features.operators.openshift.io/token-auth-azure: "false"
     features.operators.openshift.io/token-auth-gcp: "false"
     operatorframework.io/suggested-namespace: openstack-operators
+    operators.openshift.io/valid-subscription: '["OpenShift Container Platform", "OpenShift
+      Platform Plus"]'
   name: watcher-operator.v0.0.0
   namespace: placeholder
 spec:


### PR DESCRIPTION
Manual cherry-pick from https://github.com/openstack-k8s-operators/watcher-operator/pull/257

This annotation is technically optional, but it's needed for downstream productization[1]:

> Free-form array for listing any specific subscriptions that are
> required to use the Operator

Adding it here simplifies downstream CSV post-processing.

[RELDEL-7851](https://issues.redhat.com//browse/RELDEL-7851)

[1] https://docs.okd.io/4.18/operators/operator_sdk/osdk-generating-csvs.html#osdk-csv-annotations-other_osdk-generating-csvs

(cherry picked from commit cf65968beff26a3e355d53bf18f9be9c8a580fdc)