### PR TITLE
Modify edpm scenarios to install with and without nova-notifications

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -14,18 +14,20 @@
 
 - job:
     name: watcher-operator-base
+    nodeset: centos-9-medium-2x-centos-9-crc-cloud-ocp-4-18-1-3xl
     parent: podified-multinode-edpm-deployment-crc-2comp
     description: |
       A multinode EDPM Zuul job which has one ansible controller, one
       extracted crc and two computes. It will be used for testing watcher-operator.
     vars:
+      watcher_scenario: "edpm"
       cifmw_extras:
         - "@{{ ansible_user_dir }}/{{ zuul.projects['github.com/openstack-k8s-operators/ci-framework'].
            src_dir }}/scenarios/centos-9/multinode-ci.yml"
         - "@{{ ansible_user_dir }}/{{ zuul.projects['github.com/openstack-k8s-operators/ci-framework'].
            src_dir }}/scenarios/centos-9/horizon.yml"
         - "@{{ ansible_user_dir }}/{{ zuul.projects['github.com/openstack-k8s-operators/watcher-operator'].
-           src_dir }}/ci/scenarios/edpm.yml"
+           src_dir }}/ci/scenarios/{{ watcher_scenario }}.yml"
         - "@{{ ansible_user_dir }}/{{ zuul.projects['github.com/openstack-k8s-operators/watcher-operator'].
            src_dir }}/ci/tests/watcher-tempest.yml"
 
@@ -42,6 +44,7 @@
       cifmw_dlrn_report_result: true
       cifmw_update_containers_openstack: true
       cifmw_update_containers_watcher: true
+      watcher_scenario: "edpm"
       cifmw_extras:
         - "@{{ ansible_user_dir }}/{{ zuul.projects['github.com/openstack-k8s-operators/ci-framework'].
            src_dir }}/scenarios/centos-9/multinode-ci.yml"
@@ -50,7 +53,7 @@
         - "@{{ ansible_user_dir }}/{{ zuul.projects['github.com/openstack-k8s-operators/ci-framework'].
            src_dir }}/scenarios/centos-9/horizon.yml"
         - "@{{ ansible_user_dir }}/{{ zuul.projects['github.com/openstack-k8s-operators/watcher-operator'].
-           src_dir }}/ci/scenarios/edpm.yml"
+           src_dir }}/ci/scenarios/{{ watcher_scenario }}.yml"
         - "@{{ ansible_user_dir }}/{{ zuul.projects['github.com/openstack-k8s-operators/watcher-operator'].
            src_dir }}/ci/tests/watcher-tempest.yml"
       fetch_dlrn_hash: false
@@ -142,7 +145,6 @@
       cifmw_repo_setup_promotion: podified-ci-testing
       cifmw_build_containers_force: true
       cifmw_build_containers_image_tag: watcher_latest
-
 - job:
     name: watcher-operator-validation-epoxy
     parent: watcher-operator-validation-base
@@ -154,6 +156,7 @@
       openstack watcher services containers from meta content provider.
       It will test current-podified control plane EDPM deployment with openstack watcher
       master content. It deploys watcher using TLSe, and creates the certificates to use.
+      Nova notifications are not enabled on this job.
     extra-vars:
       # Override zuul meta content provider provided content_provider_dlrn_md5_hash
       # var. As returned dlrn md5 hash comes from master release but job is using
@@ -182,6 +185,7 @@
         - repository: "https://opendev.org/openstack/watcher-tempest-plugin.git"
           changeRepository: "https://review.opendev.org/openstack/watcher-tempest-plugin"
           changeRefspec: "380572db57798530b64dcac14c6b01b0382c5d8e"
+      watcher_scenario: "edpm-no-notifications"
 
 - job:
     name: watcher-operator-validation-epoxy-ocp4-16

--- a/ci/scenarios/edpm-no-notifications.yml
+++ b/ci/scenarios/edpm-no-notifications.yml
@@ -1,0 +1,110 @@
+---
+watcher_repo: "{{ ansible_user_dir }}/src/github.com/openstack-k8s-operators/watcher-operator"
+watcher_coo_hook: "{{ watcher_repo }}/ci/playbooks/deploy_cluster_observability_operator.yaml"
+prometheus_admin_api_hook: "{{ watcher_repo }}/ci/playbooks/prometheus_admin_api.yaml"
+
+# Watcher deploy playbooks
+pre_deploy_create_coo_subscription:
+  - name: Deploy cluster-observability-operator
+    type: playbook
+    source: "{{ watcher_coo_hook }}"
+post_deploy:
+  - name: Download needed tools
+    type: playbook
+    inventory: "/home/zuul/src/github.com/openstack-k8s-operators/install_yamls/devsetup/hosts"
+    source: "/home/zuul/src/github.com/openstack-k8s-operators/install_yamls/devsetup/download_tools.yaml"
+  - name: Patch Openstack Prometheus to enable admin API
+    type: playbook
+    source: "{{ prometheus_admin_api_hook }}"
+
+cifmw_edpm_prepare_kustomizations:
+  - apiVersion: kustomize.config.k8s.io/v1beta1
+    kind: Kustomization
+    namespace: openstack
+    patches:
+    - patch: |-
+        apiVersion: core.openstack.org/v1beta1
+        kind: OpenStackControlPlane
+        metadata:
+          name: controlplane
+        spec:
+          telemetry:
+            enabled: true
+            template:
+              ceilometer:
+                enabled: true
+              metricStorage:
+                enabled: true
+                customMonitoringStack:
+                  alertmanagerConfig:
+                    disabled: true
+                  prometheusConfig:
+                    enableRemoteWriteReceiver: true
+                    persistentVolumeClaim:
+                      resources:
+                        requests:
+                          storage: 20G
+                    replicas: 1
+                    scrapeInterval: 30s
+                  resourceSelector:
+                    matchLabels:
+                      service: metricStorage
+                  retention: 24h
+      target:
+        kind: OpenStackControlPlane
+    - patch: |-
+        apiVersion: core.openstack.org/v1beta1
+        kind: OpenStackControlPlane
+        metadata:
+          name: controlplane
+        spec:
+          telemetry:
+            template:
+              metricStorage:
+                monitoringStack: null
+      target:
+        kind: OpenStackControlPlane
+    - patch : |-
+        apiVersion: core.openstack.org/v1beta1
+        kind: OpenStackControlPlane
+        metadata:
+          name: controlplane
+        spec:
+          watcher:
+            enabled: true
+            template:
+              decisionengineServiceTemplate:
+                customServiceConfig: |
+                  [watcher_cluster_data_model_collectors.compute]
+                  period = 60
+                  [watcher_cluster_data_model_collectors.storage]
+                  period = 60
+      target:
+        kind: OpenStackControlPlane
+
+cifmw_edpm_prepare_timeout: 60
+
+cifmw_install_yamls_whitelisted_vars:
+  - 'WATCHER_REPO'
+  - 'WATCHER_BRANCH'
+  - 'OUTPUT_DIR'
+
+cifmw_update_containers_registry: >-
+  {%- if content_provider_os_registry_url is defined and content_provider_os_registry_url != 'null' and cifmw_repo_setup_release == 'master' -%}
+  {{ content_provider_os_registry_url | split('/') | first }}
+  {%- elif content_provider_os_registry_url is defined and content_provider_os_registry_url == 'null' and cifmw_repo_setup_release == 'master' -%}
+  quay.rdoproject.org
+  {%- elif watcher_registry_url is defined -%}
+  {{ watcher_registry_url | split('/') | first }}
+  {%- else -%}
+  quay.io
+  {%- endif -%}
+
+cifmw_update_containers_tag: >-
+  {%- if content_provider_os_registry_url is defined and content_provider_os_registry_url != 'null' -%}
+  watcher_latest
+  {%- elif content_provider_os_registry_url is defined and content_provider_os_registry_url == 'null' and cifmw_repo_setup_release == 'master' -%}
+  current-tested
+  {%- else -%}
+  current-podified
+  {%- endif -%}

--- a/ci/scenarios/edpm.yml
+++ b/ci/scenarios/edpm.yml
@@ -22,65 +22,84 @@ cifmw_edpm_prepare_kustomizations:
     kind: Kustomization
     namespace: openstack
     patches:
-    - patch: |-
-        apiVersion: core.openstack.org/v1beta1
-        kind: OpenStackControlPlane
-        metadata:
-          name: controlplane
-        spec:
-          telemetry:
-            enabled: true
-            template:
-              ceilometer:
-                enabled: true
-              metricStorage:
-                enabled: true
-                customMonitoringStack:
-                  alertmanagerConfig:
-                    disabled: true
-                  prometheusConfig:
-                    enableRemoteWriteReceiver: true
-                    persistentVolumeClaim:
-                      resources:
-                        requests:
-                          storage: 20G
-                    replicas: 1
-                    scrapeInterval: 30s
-                  resourceSelector:
-                    matchLabels:
-                      service: metricStorage
-                  retention: 24h
-      target:
-        kind: OpenStackControlPlane
-    - patch: |-
-        apiVersion: core.openstack.org/v1beta1
-        kind: OpenStackControlPlane
-        metadata:
-          name: controlplane
-        spec:
-          telemetry:
-            template:
-              metricStorage:
-                monitoringStack: null
-      target:
-        kind: OpenStackControlPlane
-    - patch : |-
-        apiVersion: core.openstack.org/v1beta1
-        kind: OpenStackControlPlane
-        metadata:
-          name: controlplane
-        spec:
-          watcher:
-            enabled: true
-            template:
-              decisionengineServiceTemplate:
-                customServiceConfig: |
-                  [watcher_cluster_data_model_collectors.compute]
-                  period = 60
-                  [watcher_cluster_data_model_collectors.storage]
-                  period = 60
-      target:
-        kind: OpenStackControlPlane
+      - patch: |-
+          apiVersion: core.openstack.org/v1beta1
+          kind: OpenStackControlPlane
+          metadata:
+            name: controlplane
+          spec:
+            telemetry:
+              enabled: true
+              template:
+                ceilometer:
+                  enabled: true
+                metricStorage:
+                  enabled: true
+                  customMonitoringStack:
+                    alertmanagerConfig:
+                      disabled: true
+                    prometheusConfig:
+                      enableRemoteWriteReceiver: true
+                      persistentVolumeClaim:
+                        resources:
+                          requests:
+                            storage: 20G
+                      replicas: 1
+                      scrapeInterval: 30s
+                    resourceSelector:
+                      matchLabels:
+                        service: metricStorage
+                    retention: 24h
+        target:
+          kind: OpenStackControlPlane
+      - patch: |-
+          - op: remove
+            path: /spec/telemetry/template/metricStorage/monitoringStack
+        target:
+          kind: OpenStackControlPlane
+      - patch: |-
+          apiVersion: core.openstack.org/v1beta1
+          kind: OpenStackControlPlane
+          metadata:
+            name: controlplane
+          spec:
+            nova:
+              template:
+                notificationsBusInstance: rabbitmq-notifications
+        target:
+          kind: OpenStackControlPlane
+      - patch: |-
+          apiVersion: core.openstack.org/v1beta1
+          kind: OpenStackControlPlane
+          metadata:
+            name: controlplane
+          spec:
+            rabbitmq:
+              templates:
+                rabbitmq-notifications:
+                  delayStartSeconds: 30
+                  override:
+                    service:
+                      metadata:
+                        annotations:
+                          metallb.universe.tf/address-pool: internalapi
+                          metallb.universe.tf/loadBalancerIPs: 172.17.0.87
+                      spec:
+                        type: LoadBalancer
+        target:
+          kind: OpenStackControlPlane
+      - patch: |-
+          apiVersion: core.openstack.org/v1beta1
+          kind: OpenStackControlPlane
+          metadata:
+            name: controlplane
+          spec:
+            watcher:
+              enabled: true
+              template:
+                notificationsBusInstance: rabbitmq-notifications
+        target:
+          kind: OpenStackControlPlane
 
 cifmw_edpm_prepare_timeout: 60
 


### PR DESCRIPTION
This PR adds the posibility of using different edpm scenarios to add watcher to kustomize object but using different scenarios depending on the configuration of watcher that we want to use

nova-notifications usage is added to default scenario (edpm), but not on epoxy jobs (edpm-no-notifications), where it is also decreased the model obtain process to 60 seconds.

Nodeset is also modified on default job, required because adding the new rabbitmq queue for nova-notifications


Results of the last CI Run:

Master: https://logserver.rdoproject.org/2a3/rdoproject.org/2a3fd1dd32cf4a1e94bab0a38d4ff9e5/controller/ci-framework-data/logs/openstack-k8s-operators-openstack-must-gather/namespaces/openstack/crs/watchers.watcher.openstack.org/watcher.yaml

Epoxy: https://logserver.rdoproject.org/046/rdoproject.org/046004fc67444df4a8fa922015bd4261/controller/ci-framework-data/logs/openstack-k8s-operators-openstack-must-gather/namespaces/openstack/crs/watchers.watcher.openstack.org/watcher.yaml