### PR TITLE
[WIP] Enable Ceph as cinder backend with a single pool

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -5,12 +5,14 @@
     merge-mode: rebase
     templates:
       - opendev-master-watcher-operator-pipeline
-      - opendev-epoxy-watcher-operator-pipeline
+      # DNM jgilaber temporarily restrict jobs to the one that is testing the
+      # changes to avoid wasting resources
+      # - opendev-epoxy-watcher-operator-pipeline
     github-check:
       jobs:
         - noop
-        - watcher-operator-doc-preview
-        - watcher-operator-kuttl
+        # - watcher-operator-doc-preview
+        # - watcher-operator-kuttl
 
 - job:
     name: watcher-operator-base
@@ -233,8 +235,23 @@
     voting: false
     description: |
       A Zuul job consuming content from openstack-meta-content-provider-master
-      and deploying EDPM with master content.
+      and deploying EDPM with master content and ceph storage backend.
     vars:
+      cifmw_extras:
+        - "@{{ ansible_user_dir }}/{{ zuul.projects['github.com/openstack-k8s-operators/ci-framework'].
+           src_dir }}/scenarios/centos-9/multinode-ci.yml"
+        - "@{{ ansible_user_dir }}/{{ zuul.projects['github.com/openstack-k8s-operators/ci-framework'].
+           src_dir }}/scenarios/centos-9/horizon.yml"
+        - "@{{ ansible_user_dir }}/{{ zuul.projects['github.com/openstack-k8s-operators/ci-framework'].
+           src_dir }}/scenarios/centos-9/hci_ceph_backends.yml"
+        - "@{{ ansible_user_dir }}/{{ zuul.projects['github.com/openstack-k8s-operators/watcher-operator'].
+           src_dir }}/ci/scenarios/edpm.yml"
+        - "@{{ ansible_user_dir }}/{{ zuul.projects['github.com/openstack-k8s-operators/watcher-operator'].
+           src_dir }}/ci/tests/watcher-tempest.yml"
+        - "@{{ ansible_user_dir }}/{{ zuul.projects['github.com/openstack-k8s-operators/watcher-operator'].
+           src_dir }}/ci/tests/watcher-tempest-ceph.yml"
+        - "@{{ ansible_user_dir }}/{{ zuul.projects['github.com/openstack-k8s-operators/watcher-operator'].
+           src_dir }}/ci/scenarios/ceph.yml"
       cifmw_repo_setup_branch: master
       # To consume containers from meta content provider
       cifmw_update_containers_openstack: true
@@ -244,12 +261,81 @@
       watcher_services_tag: watcher_latest
       watcher_registry_url: "{{ content_provider_os_registry_url }}"
       cifmw_test_operator_tempest_image_tag: watcher_latest
-
     extra-vars:
       # Override zuul meta content provider provided content_provider_dlrn_md5_hash
       # var. As returned dlrn md5 hash comes from master release but job is using
       # antelope content.
       content_provider_dlrn_md5_hash: ''
+      # jgilaber: add storage-mgmt network to nodes for ceph
+      crc_ci_bootstrap_cloud_name: "{{ nodepool.cloud | replace('-nodepool-tripleo','') }}"
+      crc_ci_bootstrap_networking:
+        networks:
+          default:
+            mtu: "{{ ('ibm' in nodepool.cloud) | ternary('1440', '1500') }}"
+            router_net: ""
+            transparent: true
+            range: 192.168.122.0/24
+          internal-api:
+            vlan: 20
+            range: 172.17.0.0/24
+          storage:
+            vlan: 21
+            range: 172.18.0.0/24
+          tenant:
+            vlan: 22
+            range: 172.19.0.0/24
+          storage-mgmt:
+            vlan: 23
+            range: 172.20.0.0/24
+        instances:
+          controller:
+            networks:
+              default:
+                ip: 192.168.122.11
+          crc:
+            networks:
+              default:
+                ip: 192.168.122.10
+              internal-api:
+                ip: 172.17.0.5
+              storage:
+                ip: 172.18.0.5
+              tenant:
+                ip: 172.19.0.5
+              storage-mgmt:
+                ip: 172.20.0.5
+          compute-0:
+            networks:
+              default:
+                ip: 192.168.122.100
+              internal-api:
+                ip: 172.17.0.100
+                config_nm: false
+              storage:
+                ip: 172.18.0.100
+                config_nm: false
+              tenant:
+                ip: 172.19.0.100
+                config_nm: false
+              storage-mgmt:
+                ip: 172.20.0.100
+                config_nm: false
+          compute-1:
+            networks:
+              default:
+                ip: 192.168.122.101
+              internal-api:
+                ip: 172.17.0.101
+                config_nm: false
+              storage:
+                ip: 172.18.0.101
+                config_nm: false
+              tenant:
+                ip: 172.19.0.101
+                config_nm: false
+              storage-mgmt:
+                ip: 172.20.0.101
+                config_nm: false
 
 ##########################################################
 #                                                        #

--- a/ci/scenarios/ceph.yml
+++ b/ci/scenarios/ceph.yml
@@ -1,0 +1,38 @@
+---
+cifmw_edpm_deploy_hci: true
+cifmw_ceph_daemons_layout:
+  rgw_enabled: true
+  dashboard_enabled: true
+  cephfs_enabled: true
+  ceph_nfs_enabled: true
+# Override the Ceph container tag and deploy Squid
+cifmw_cephadm_container_tag: "v19"
+# Override the Ceph Tools repo and install cephadm Squid
+cifmw_cephadm_repository_override: true
+cifmw_cephadm_version: "squid"
+cifmw_cephadm_prepare_host: true
+cifmw_services_manila_enabled: false
+cifmw_hci_prepare_extra_services:
+  - telemetry
+
+# NOTE(jgilaber): we might want to merge this file into scenarios/edpm.yml,
+# # depending on how many jobs will have cinder volumes enabled
+ci_framework_base_src_dir: "{{ ansible_user_dir  }}/{{ zuul.projects['github.com/openstack-k8s-operators/ci-framework'].src_dir  }}"
+install_yamls_src_dir: "{{ ansible_user_dir }}/{{ zuul.projects['github.com/openstack-k8s-operators/install_yamls'].src_dir }}"
+post_deploy:
+  - name: Download needed tools
+    type: playbook
+    inventory: "{{ install_yamls_src_dir }}/devsetup/hosts"
+    source: "{{ install_yamls_src_dir }}/devsetup/download_tools.yaml"
+  - name: Patch Openstack Prometheus to enable admin API
+    type: playbook
+    source: "{{ prometheus_admin_api_hook }}"
+  - name: 81 Kustomize OpenStack CR with Ceph
+    type: playbook
+    source: "{{ ci_framework_base_src_dir }}/hooks/playbooks/control_plane_ceph_backends.yml"
+  - name: 82 Kustomize and update Control Plane
+    type: playbook
+    source: "{{ ci_framework_base_src_dir }}/hooks/playbooks/control_plane_kustomize_deploy.yml"
+
+# jgilaber: override hook defined in ci-framework that we don't need
+pre_tests: []

--- a/ci/tests/watcher-tempest-ceph.yml
+++ b/ci/tests/watcher-tempest-ceph.yml
@@ -1,0 +1,19 @@
+# get the tempest configuration from watcher-waster.yml, with the exception of
+# not skipping volume_migration tests
+cifmw_test_operator_tempest_exclude_list: |
+  watcher_tempest_plugin.*client_functional.*
+  watcher_tempest_plugin.tests.scenario.test_execute_strategies.TestExecuteStrategies.test_execute_storage_capacity_balance_strategy
+  watcher_tempest_plugin.*\[.*\breal_load\b.*\].*
+
+# jgilaber: because of how its implemented cifmw_test_operator_tempest_tempestconf_config
+# takes precedence over cifmw_tempest_tempestconf 
+# https://github.com/openstack-k8s-operators/ci-framework/blob/3c126ed07810244e4700e0030db1def684056fd0/roles/test_operator/defaults/main.yml#L166
+# and we need to override the value defined in ci-framework/scenarios/centos-9/hci_ceph_backends.yml
+# https://github.com/openstack-k8s-operators/ci-framework/blob/3c126ed07810244e4700e0030db1def684056fd0/scenarios/centos-9/hci_ceph_backends.yml#L43
+cifmw_test_operator_tempest_tempestconf_config:
+    overrides: |
+      {{ cifmw_tempest_tempestconf_config.overrides }}
+      identity.v3_endpoint_type public
+      share.run_share_group_tests false
+      share.capability_storage_protocol cephfs
+      share.suppress_errors_in_cleanup true


### PR DESCRIPTION
Deploy an HCI configuration using cifmw and use it as backend
for cinder. This is needed to test volume migrations and depending on
the result we might enable it in all jobs or only in some.

Deploy with only one pool to test that the test is skipped if there are
not at least two available pools to cinder.

Depends-On: https://review.opendev.org/c/openstack/watcher-tempest-plugin/+/958644
Depends-On: https://review.opendev.org/c/openstack/watcher/+/960265
Depends-On: https://github.com/openstack-k8s-operators/watcher-operator/pull/269
