### PR TITLE
DNM Checking removing nested ansible execution for 99-logs

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -1,4 +1,5 @@
 ---
+# dpawlik - test
 - project:
     name: openstack-k8s-operators/watcher-operator
     default-branch: main


### PR DESCRIPTION
There was exception done for run_logs tasks in cifmw_setup role, that calling that role was used in e2e-collect-logs using ansible binary (not ansible-playbook as it is in multiple places). There is no need to run as nested ansible, if it can be called directly.

Depends-On: https://github.com/openstack-k8s-operators/ci-framework/pull/3242