### PR TITLE
Remove deprecated cifmw_tempest_tempestconf_config

### DIFF
--- a/ci/tests/watcher-tempest.yml
+++ b/ci/tests/watcher-tempest.yml
@@ -1,5 +1,5 @@
 # # Tempest and test-operator configurations
-cifmw_tempest_tempestconf_config:
+cifmw_test_operator_tempest_tempestconf_config:
   overrides: |
     compute.min_microversion 2.56
     compute.min_compute_nodes 2


### PR DESCRIPTION
The cifmw_tempest_tempestconf_config has been deprecated for a while, so it would be the best to start using the new alternative cifmw_test_operator_tempest_tempestconf_config. There should be no impact on the jobs, it should just let us cleanup the deprecated parameter.