### PR TITLE
Watch cinder endpoint in WatcherDecisionEngine

### DIFF
--- a/controllers/watcher_common.go
+++ b/controllers/watcher_common.go
@@ -36,6 +36,8 @@ const (
 	tlsAPIPublicField       = ".spec.tls.api.public.secretName"
 	topologyField           = ".spec.topologyRef.Name"
 	memcachedInstanceField  = ".spec.memcachedInstance"
+	// service label for cinder endpoint
+	endpointCinder = "cinder"
 )
 
 var (
@@ -65,6 +67,9 @@ var (
 		caBundleSecretNameField,
 		topologyField,
 		memcachedInstanceField,
+	}
+	endpointList = []string{
+		endpointCinder,
 	}
 )
 

--- a/tests/kuttl/test-suites/default/deps/kustomization.yaml
+++ b/tests/kuttl/test-suites/default/deps/kustomization.yaml
@@ -21,6 +21,7 @@ secretGenerator:
   - NovaAPIDatabasePassword=password
   - NovaCell0DatabasePassword=password
   - NovaCell1DatabasePassword=password
+  - CinderPassword=password
   - MetadataSecret=42
   name: osp-secret
 generatorOptions:

--- a/tests/kuttl/test-suites/default/watcher-cinder/00-cleanup-watcher.yaml
+++ b/tests/kuttl/test-suites/default/watcher-cinder/00-cleanup-watcher.yaml
@@ -1,0 +1,1 @@
+../common/cleanup-watcher.yaml

--- a/tests/kuttl/test-suites/default/watcher-cinder/01-assert.yaml
+++ b/tests/kuttl/test-suites/default/watcher-cinder/01-assert.yaml
@@ -1,0 +1,21 @@
+apiVersion: watcher.openstack.org/v1beta1
+kind: Watcher
+metadata:
+  finalizers:
+  - openstack.org/watcher
+  name: watcher-kuttl
+  namespace: watcher-kuttl-default
+status:
+  # we just want to assert that the watcher is ready in this test
+  apiServiceReadyCount: 1
+  applierServiceReadyCount: 1
+  decisionengineServiceReadyCount: 1
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+namespaced: true
+commands:
+  - script: |
+      set -euxo pipefail
+      # check that the decision engine correctly detects that there is no cinder service
+      [ "$(oc logs -n $NAMESPACE watcher-kuttl-decision-engine-0 | grep -c 'Block storage service is not enabled, skipping storage collector')" == 2 ]

--- a/tests/kuttl/test-suites/default/watcher-cinder/01-deploy-watcher-no-cinder.yaml
+++ b/tests/kuttl/test-suites/default/watcher-cinder/01-deploy-watcher-no-cinder.yaml
@@ -1,0 +1,10 @@
+apiVersion: watcher.openstack.org/v1beta1
+kind: Watcher
+metadata:
+  name: watcher-kuttl
+  namespace: watcher-kuttl-default
+spec:
+  databaseInstance: "openstack"
+  apiServiceTemplate:
+    tls:
+      caBundleSecretName: "combined-ca-bundle"

--- a/tests/kuttl/test-suites/default/watcher-cinder/02-assert.yaml
+++ b/tests/kuttl/test-suites/default/watcher-cinder/02-assert.yaml
@@ -1,0 +1,32 @@
+apiVersion: watcher.openstack.org/v1beta1
+kind: Watcher
+metadata:
+  finalizers:
+  - openstack.org/watcher
+  name: watcher-kuttl
+  namespace: watcher-kuttl-default
+status:
+  # we just want to assert that the watcher is ready in this test
+  apiServiceReadyCount: 1
+  applierServiceReadyCount: 1
+  decisionengineServiceReadyCount: 1
+---
+apiVersion: keystone.openstack.org/v1beta1
+kind: KeystoneService
+metadata:
+  name: cinderv3
+---
+apiVersion: keystone.openstack.org/v1beta1
+kind: KeystoneEndpoint
+metadata:
+  name: cinderv3
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+namespaced: true
+commands:
+  - script: |
+      set -euxo pipefail
+      # check that the decision detects that there is a cinder service and
+      # does not log that storage collector is skipped
+      [ "$(oc logs -n $NAMESPACE watcher-kuttl-decision-engine-0 |grep -c 'Block storage service is not enabled, skipping storage collector')" == 0 ]

--- a/tests/kuttl/test-suites/default/watcher-cinder/02-deploy-cinder.yaml
+++ b/tests/kuttl/test-suites/default/watcher-cinder/02-deploy-cinder.yaml
@@ -1,0 +1,13 @@
+apiVersion: core.openstack.org/v1beta1
+kind: OpenStackControlPlane
+metadata:
+  name: openstack
+spec:
+  cinder:
+    enabled: true
+    template:
+      databaseInstance: openstack
+      databaseAccount: cinder
+      secret: osp-secret
+      cinderAPI:
+        replicas: 1

--- a/tests/kuttl/test-suites/default/watcher-cinder/03-assert.yaml
+++ b/tests/kuttl/test-suites/default/watcher-cinder/03-assert.yaml
@@ -1,0 +1,21 @@
+apiVersion: watcher.openstack.org/v1beta1
+kind: Watcher
+metadata:
+  finalizers:
+  - openstack.org/watcher
+  name: watcher-kuttl
+  namespace: watcher-kuttl-default
+status:
+  # we just want to assert that the watcher is ready in this test
+  apiServiceReadyCount: 1
+  applierServiceReadyCount: 1
+  decisionengineServiceReadyCount: 1
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+namespaced: true
+commands:
+  - script: |
+      set -euxo pipefail
+      # check that the decision engine correctly detects that there is no cinder service
+      [ "$(oc logs -n $NAMESPACE watcher-kuttl-decision-engine-0 |grep -c 'Block storage service is not enabled, skipping storage collector')" == 2 ]

--- a/tests/kuttl/test-suites/default/watcher-cinder/03-remove-cinder.yaml
+++ b/tests/kuttl/test-suites/default/watcher-cinder/03-remove-cinder.yaml
@@ -1,0 +1,7 @@
+apiVersion: core.openstack.org/v1beta1
+kind: OpenStackControlPlane
+metadata:
+  name: openstack
+spec:
+  cinder:
+    enabled: false

--- a/tests/kuttl/test-suites/default/watcher-cinder/04-cleanup-watcher.yaml
+++ b/tests/kuttl/test-suites/default/watcher-cinder/04-cleanup-watcher.yaml
@@ -1,0 +1,1 @@
+../common/cleanup-watcher.yaml

--- a/tests/kuttl/test-suites/default/watcher-cinder/04-errors.yaml
+++ b/tests/kuttl/test-suites/default/watcher-cinder/04-errors.yaml
@@ -1,0 +1,1 @@
+../common/cleanup-errors.yaml


### PR DESCRIPTION
Watch the cinder KeystoneEndpoint in the WatcherDecisionEngine to
detect changes and trigger reconciliation when endpoints are
modified. This ensures the decision engine is reconciled if Cinder
is enabled or disabled to ensure the storage collector is properly
configured.

The endpoint URL hashing logic detects when cached endpoint URLs
need to be updated and triggers deployment restarts accordingly.

Assisted-By: Cursor (claude-4-sonnet)

Depends-On: https://github.com/openstack-k8s-operators/watcher-operator/pull/278

Resolves: [OSPRH-20349](https://issues.redhat.com//browse/OSPRH-20349)
