### PR TITLE
Enable continuous audit tests in CI

### DIFF
--- a/ci/tests/watcher-tempest.yml
+++ b/ci/tests/watcher-tempest.yml
@@ -21,6 +21,7 @@ cifmw_tempest_tempestconf_config:
     optimize.prometheus_ssl_cert_dir /etc/prometheus/secrets/combined-ca-bundle
     optimize.podified_kubeconfig_path /home/zuul/.crc/machines/crc/kubeconfig
     optimize.podified_namespace openstack
+    optimize.run_continuous_audit_tests true
 
 run_tempest: false
 cifmw_test_operator_tempest_concurrency: 1


### PR DESCRIPTION
It is disabled by default in watcher-tempest-plugin since not all branches will get the fix right now.