### PR TITLE
Modernize Go code with latest style conventions

### DIFF
--- a/controllers/watcher_common.go
+++ b/controllers/watcher_common.go
@@ -217,7 +217,7 @@ func (r *Reconcilers) OverrideRequeueTimeout(timeout time.Duration) {
 
 type conditionUpdater interface {
 	Set(c *condition.Condition)
-	MarkTrue(t condition.Type, messageFormat string, messageArgs ...interface{})
+	MarkTrue(t condition.Type, messageFormat string, messageArgs ...any)
 }
 
 // ensureSecret - ensures that the Secret object exists and the expected fields
@@ -290,7 +290,7 @@ func GenerateConfigsGeneric(
 	ctx context.Context, helper *helper.Helper,
 	instance client.Object,
 	envVars *map[string]env.Setter,
-	templateParameters map[string]interface{},
+	templateParameters map[string]any,
 	customData map[string]string,
 	cmLabels map[string]string,
 	scripts bool,

--- a/controllers/watcher_controller.go
+++ b/controllers/watcher_controller.go
@@ -792,7 +792,7 @@ func (r *WatcherReconciler) generateServiceConfigDBJobs(
 	labels := labels.GetLabels(instance, labels.GetGroupLabel(watcher.ServiceName), map[string]string{})
 	databaseAccount := db.GetAccount()
 	databaseSecret := db.GetSecret()
-	templateParameters := map[string]interface{}{
+	templateParameters := map[string]any{
 		"DatabaseConnection": fmt.Sprintf("mysql+pymysql://%s:%s@%s/%s?read_default_file=/etc/my.cnf",
 			databaseAccount.Spec.UserName,
 			string(databaseSecret.Data[mariadbv1.DatabasePasswordSelector]),

--- a/controllers/watcherapi_controller.go
+++ b/controllers/watcherapi_controller.go
@@ -444,7 +444,7 @@ func (r *WatcherAPIReconciler) generateServiceConfigs(
 	if instance.Spec.TLS.CaBundleSecretName != "" {
 		CaFilePath = tls.DownstreamTLSCABundlePath
 	}
-	templateParameters := map[string]interface{}{
+	templateParameters := map[string]any{
 		"DatabaseConnection": fmt.Sprintf("mysql+pymysql://%s:%s@%s/%s?read_default_file=/etc/my.cnf",
 			databaseUsername,
 			databasePassword,
@@ -478,9 +478,9 @@ func (r *WatcherAPIReconciler) generateServiceConfigs(
 	}
 
 	// create httpd  vhost template parameters
-	httpdVhostConfig := map[string]interface{}{}
+	httpdVhostConfig := map[string]any{}
 	for _, endpt := range []service.Endpoint{service.EndpointInternal, service.EndpointPublic} {
-		endptConfig := map[string]interface{}{}
+		endptConfig := map[string]any{}
 		endptConfig["ServerName"] = fmt.Sprintf("%s-%s.%s.svc", watcher.ServiceName, endpt.String(), instance.Namespace)
 		endptConfig["TLS"] = false // default TLS to false, and set it below to true if enabled
 		if instance.Spec.TLS.API.Enabled(endpt) {

--- a/controllers/watcherapplier_controller.go
+++ b/controllers/watcherapplier_controller.go
@@ -412,7 +412,7 @@ func (r *WatcherApplierReconciler) generateServiceConfigs(
 	if instance.Spec.TLS.CaBundleSecretName != "" {
 		CaFilePath = tls.DownstreamTLSCABundlePath
 	}
-	templateParameters := map[string]interface{}{
+	templateParameters := map[string]any{
 		"DatabaseConnection": fmt.Sprintf("mysql+pymysql://%s:%s@%s/%s?read_default_file=/etc/my.cnf",
 			databaseUsername,
 			databasePassword,

--- a/controllers/watcherdecisionengine_controller.go
+++ b/controllers/watcherdecisionengine_controller.go
@@ -537,7 +537,7 @@ func (r *WatcherDecisionEngineReconciler) generateServiceConfigs(
 	if instance.Spec.TLS.CaBundleSecretName != "" {
 		CaFilePath = tls.DownstreamTLSCABundlePath
 	}
-	templateParameters := map[string]interface{}{
+	templateParameters := map[string]any{
 		"DatabaseConnection": fmt.Sprintf("mysql+pymysql://%s:%s@%s/%s?read_default_file=/etc/my.cnf",
 			databaseUsername,
 			databasePassword,

--- a/tests/functional/base_test.go
+++ b/tests/functional/base_test.go
@@ -32,8 +32,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func GetDefaultWatcherSpec() map[string]interface{} {
-	return map[string]interface{}{
+func GetDefaultWatcherSpec() map[string]any {
+	return map[string]any{
 		"databaseInstance": "openstack",
 		"secret":           SecretName,
 	}
@@ -97,36 +97,36 @@ func CreateInternalTopLevelSecretQuorum() *corev1.Secret {
 }
 
 // Second Watcher Spec to test proper parameters substitution
-func GetNonDefaultWatcherSpec() map[string]interface{} {
-	return map[string]interface{}{
+func GetNonDefaultWatcherSpec() map[string]any {
+	return map[string]any{
 		"apiContainerImageURL": "fake-API-Container-URL",
 		"secret":               SecretName,
 		"preserveJobs":         true,
 		"databaseInstance":     "fakeopenstack",
 		"serviceUser":          "fakeuser",
 		"customServiceConfig":  "# Global config",
-		"apiServiceTemplate": map[string]interface{}{
+		"apiServiceTemplate": map[string]any{
 			"replicas":            2,
 			"nodeSelector":        map[string]string{"foo": "bar"},
 			"customServiceConfig": "# Service config",
-			"tls": map[string]interface{}{
+			"tls": map[string]any{
 				"caBundleSecretName": "combined-ca-bundle",
 			},
 		},
 		"prometheusSecret":         "custom-prometheus-config",
 		"applierContainerImageURL": "fake-Applier-Container-URL",
-		"applierServiceTemplate": map[string]interface{}{
+		"applierServiceTemplate": map[string]any{
 			"replicas":            1,
 			"nodeSelector":        map[string]string{"foo": "bar"},
 			"customServiceConfig": "# Service config Applier",
 		},
 		"decisionengineContainerImageURL": "fake-DecisionEngine-Container-URL",
-		"decisionengineServiceTemplate": map[string]interface{}{
+		"decisionengineServiceTemplate": map[string]any{
 			"replicas":            1,
 			"nodeSelector":        map[string]string{"foo": "bar"},
 			"customServiceConfig": "# Service config DecisionEngine",
 		},
-		"dbPurge": map[string]interface{}{
+		"dbPurge": map[string]any{
 			"schedule": "1 2 * * *",
 			"purgeAge": 1,
 		},
@@ -135,14 +135,14 @@ func GetNonDefaultWatcherSpec() map[string]interface{} {
 }
 
 // Watcher Spec to test TLSe
-func GetTLSeWatcherSpec() map[string]interface{} {
-	return map[string]interface{}{
+func GetTLSeWatcherSpec() map[string]any {
+	return map[string]any{
 		"secret":           SecretName,
 		"databaseInstance": "openstack",
-		"apiServiceTemplate": map[string]interface{}{
-			"tls": map[string]interface{}{
+		"apiServiceTemplate": map[string]any{
+			"tls": map[string]any{
 				"caBundleSecretName": "combined-ca-bundle",
-				"api": map[string]interface{}{
+				"api": map[string]any{
 					"internal": map[string]string{
 						"secretName": "cert-watcher-internal-svc",
 					},
@@ -155,26 +155,26 @@ func GetTLSeWatcherSpec() map[string]interface{} {
 	}
 }
 
-func GetTLSIngressWatcherSpec() map[string]interface{} {
-	return map[string]interface{}{
+func GetTLSIngressWatcherSpec() map[string]any {
+	return map[string]any{
 		"secret":           SecretName,
 		"databaseInstance": "openstack",
-		"apiServiceTemplate": map[string]interface{}{
-			"tls": map[string]interface{}{
+		"apiServiceTemplate": map[string]any{
+			"tls": map[string]any{
 				"caBundleSecretName": "combined-ca-bundle",
 			},
 		},
 	}
 }
 
-func GetTLSPodLevelWatcherSpec() map[string]interface{} {
-	return map[string]interface{}{
+func GetTLSPodLevelWatcherSpec() map[string]any {
+	return map[string]any{
 		"secret":           SecretName,
 		"databaseInstance": "openstack",
-		"apiServiceTemplate": map[string]interface{}{
-			"tls": map[string]interface{}{
+		"apiServiceTemplate": map[string]any{
+			"tls": map[string]any{
 				"caBundleSecretName": "combined-ca-bundle",
-				"api": map[string]interface{}{
+				"api": map[string]any{
 					"internal": map[string]string{
 						"secretName": "cert-watcher-internal-svc",
 					},
@@ -187,8 +187,8 @@ func GetTLSPodLevelWatcherSpec() map[string]interface{} {
 	}
 }
 
-func GetDefaultWatcherAPISpec() map[string]interface{} {
-	return map[string]interface{}{
+func GetDefaultWatcherAPISpec() map[string]any {
+	return map[string]any{
 		"databaseInstance":  "openstack",
 		"secret":            SecretName,
 		"memcachedInstance": "memcached",
@@ -197,14 +197,14 @@ func GetDefaultWatcherAPISpec() map[string]interface{} {
 	}
 }
 
-func GetTLSWatcherAPISpec() map[string]interface{} {
-	return map[string]interface{}{
+func GetTLSWatcherAPISpec() map[string]any {
+	return map[string]any{
 		"databaseInstance": "openstack",
 		"secret":           SecretName,
 		"containerImage":   "test://watcher",
-		"tls": map[string]interface{}{
+		"tls": map[string]any{
 			"caBundleSecretName": "combined-ca-bundle",
-			"api": map[string]interface{}{
+			"api": map[string]any{
 				"internal": map[string]string{
 					"secretName": "cert-watcher-internal-svc",
 				},
@@ -216,35 +216,35 @@ func GetTLSWatcherAPISpec() map[string]interface{} {
 	}
 
 }
-func GetTLSCaWatcherAPISpec() map[string]interface{} {
-	return map[string]interface{}{
+func GetTLSCaWatcherAPISpec() map[string]any {
+	return map[string]any{
 		"databaseInstance": "openstack",
 		"secret":           SecretName,
 		"containerImage":   "test://watcher",
-		"tls": map[string]interface{}{
+		"tls": map[string]any{
 			"caBundleSecretName": "combined-ca-bundle",
 		},
 	}
 }
 
-func GetServiceOverrideWatcherAPISpec() map[string]interface{} {
-	return map[string]interface{}{
+func GetServiceOverrideWatcherAPISpec() map[string]any {
+	return map[string]any{
 		"databaseInstance":  "openstack",
 		"secret":            SecretName,
 		"memcachedInstance": "memcached",
 		"serviceAccount":    "watcher-sa",
 		"containerImage":    "test://watcher",
-		"override": map[string]interface{}{
-			"service": map[string]interface{}{
-				"internal": map[string]interface{}{
-					"metadata": map[string]interface{}{
+		"override": map[string]any{
+			"service": map[string]any{
+				"internal": map[string]any{
+					"metadata": map[string]any{
 						"annotations": map[string]string{
 							"metallb.universe.tf/address-pool":    "osp-internalapi",
 							"metallb.universe.tf/loadBalancerIPs": "internal-lb-ip-1,internal-lb-ip-2",
 							"metallb.universe.tf/allow-shared-ip": "osp-internalapi",
 						},
 					},
-					"spec": map[string]interface{}{
+					"spec": map[string]any{
 						"type": "LoadBalancer",
 					},
 				},
@@ -253,8 +253,8 @@ func GetServiceOverrideWatcherAPISpec() map[string]interface{} {
 	}
 }
 
-func GetDefaultWatcherApplierSpec() map[string]interface{} {
-	return map[string]interface{}{
+func GetDefaultWatcherApplierSpec() map[string]any {
+	return map[string]any{
 		"databaseInstance":  "openstack",
 		"secret":            SecretName,
 		"memcachedInstance": "memcached",
@@ -263,8 +263,8 @@ func GetDefaultWatcherApplierSpec() map[string]interface{} {
 	}
 }
 
-func GetDefaultWatcherDecisionEngineSpec() map[string]interface{} {
-	return map[string]interface{}{
+func GetDefaultWatcherDecisionEngineSpec() map[string]any {
+	return map[string]any{
 		"databaseInstance":  "openstack",
 		"secret":            SecretName,
 		"memcachedInstance": "memcached",
@@ -273,11 +273,11 @@ func GetDefaultWatcherDecisionEngineSpec() map[string]interface{} {
 	}
 }
 
-func CreateWatcher(name types.NamespacedName, spec map[string]interface{}) client.Object {
-	raw := map[string]interface{}{
+func CreateWatcher(name types.NamespacedName, spec map[string]any) client.Object {
+	raw := map[string]any{
 		"apiVersion": "watcher.openstack.org/v1beta1",
 		"kind":       "Watcher",
-		"metadata": map[string]interface{}{
+		"metadata": map[string]any{
 			"name":      name.Name,
 			"namespace": name.Namespace,
 		},
@@ -299,11 +299,11 @@ func WatcherConditionGetter(name types.NamespacedName) condition.Conditions {
 	return instance.Status.Conditions
 }
 
-func CreateWatcherAPI(name types.NamespacedName, spec map[string]interface{}) client.Object {
-	raw := map[string]interface{}{
+func CreateWatcherAPI(name types.NamespacedName, spec map[string]any) client.Object {
+	raw := map[string]any{
 		"apiVersion": "watcher.openstack.org/v1beta1",
 		"kind":       "WatcherAPI",
-		"metadata": map[string]interface{}{
+		"metadata": map[string]any{
 			"name":      name.Name,
 			"namespace": name.Namespace,
 		},
@@ -325,11 +325,11 @@ func WatcherAPIConditionGetter(name types.NamespacedName) condition.Conditions {
 	return instance.Status.Conditions
 }
 
-func CreateWatcherApplier(name types.NamespacedName, spec map[string]interface{}) client.Object {
-	raw := map[string]interface{}{
+func CreateWatcherApplier(name types.NamespacedName, spec map[string]any) client.Object {
+	raw := map[string]any{
 		"apiVersion": "watcher.openstack.org/v1beta1",
 		"kind":       "WatcherApplier",
-		"metadata": map[string]interface{}{
+		"metadata": map[string]any{
 			"name":      name.Name,
 			"namespace": name.Namespace,
 		},
@@ -360,18 +360,18 @@ func CreateWatcherMessageBusSecret(namespace string, name string) *corev1.Secret
 	s := th.CreateSecret(
 		types.NamespacedName{Namespace: namespace, Name: name},
 		map[string][]byte{
-			"transport_url": []byte(fmt.Sprintf("rabbit://%s/fake", name)),
+			"transport_url": fmt.Appendf(nil, "rabbit://%s/fake", name),
 		},
 	)
 	logger.Info("Secret created", "name", name)
 	return s
 }
 
-func CreateWatcherDecisionEngine(name types.NamespacedName, spec map[string]interface{}) client.Object {
-	raw := map[string]interface{}{
+func CreateWatcherDecisionEngine(name types.NamespacedName, spec map[string]any) client.Object {
+	raw := map[string]any{
 		"apiVersion": "watcher.openstack.org/v1beta1",
 		"kind":       "WatcherDecisionEngine",
-		"metadata": map[string]interface{}{
+		"metadata": map[string]any{
 			"name":      name.Name,
 			"namespace": name.Namespace,
 		},
@@ -422,16 +422,16 @@ func CreateCertSecret(name types.NamespacedName) *corev1.Secret {
 // test Watcher components. It returns both the user input representation
 // in the form of map[string]string, and the Golang expected representation
 // used in the test asserts.
-func GetSampleTopologySpec(label string) (map[string]interface{}, []corev1.TopologySpreadConstraint) {
+func GetSampleTopologySpec(label string) (map[string]any, []corev1.TopologySpreadConstraint) {
 	// Build the topology Spec yaml representation
-	topologySpec := map[string]interface{}{
-		"topologySpreadConstraints": []map[string]interface{}{
+	topologySpec := map[string]any{
+		"topologySpreadConstraints": []map[string]any{
 			{
 				"maxSkew":           1,
 				"topologyKey":       corev1.LabelHostname,
 				"whenUnsatisfiable": "ScheduleAnyway",
-				"labelSelector": map[string]interface{}{
-					"matchLabels": map[string]interface{}{
+				"labelSelector": map[string]any{
+					"matchLabels": map[string]any{
 						"service": label,
 					},
 				},

--- a/tests/functional/sample_test.go
+++ b/tests/functional/sample_test.go
@@ -27,8 +27,8 @@ import (
 
 const SamplesDir = "../../config/samples/"
 
-func ReadSample(sampleFileName string) map[string]interface{} {
-	rawSample := make(map[string]interface{})
+func ReadSample(sampleFileName string) map[string]any {
+	rawSample := make(map[string]any)
 
 	bytes, err := os.ReadFile(filepath.Join(SamplesDir, sampleFileName)) //nolint:gosec // G304: File path is sanitized and controlled in test environment
 	Expect(err).ShouldNot(HaveOccurred())
@@ -43,28 +43,28 @@ func ReadSample(sampleFileName string) map[string]interface{} {
 
 func CreateWatcherFromSample(sampleFileName string, name types.NamespacedName) types.NamespacedName {
 	raw := ReadSample(sampleFileName)
-	instance := CreateWatcher(name, raw["spec"].(map[string]interface{}))
+	instance := CreateWatcher(name, raw["spec"].(map[string]any))
 	DeferCleanup(th.DeleteInstance, instance)
 	return types.NamespacedName{Name: instance.GetName(), Namespace: instance.GetNamespace()}
 }
 
 func CreateWatcherAPIFromSample(sampleFileName string, name types.NamespacedName) types.NamespacedName {
 	raw := ReadSample(sampleFileName)
-	instance := CreateWatcherAPI(name, raw["spec"].(map[string]interface{}))
+	instance := CreateWatcherAPI(name, raw["spec"].(map[string]any))
 	DeferCleanup(th.DeleteInstance, instance)
 	return types.NamespacedName{Name: instance.GetName(), Namespace: instance.GetNamespace()}
 }
 
 func CreateWatcherApplierFromSample(sampleFileName string, name types.NamespacedName) types.NamespacedName {
 	raw := ReadSample(sampleFileName)
-	instance := CreateWatcherApplier(name, raw["spec"].(map[string]interface{}))
+	instance := CreateWatcherApplier(name, raw["spec"].(map[string]any))
 	DeferCleanup(th.DeleteInstance, instance)
 	return types.NamespacedName{Name: instance.GetName(), Namespace: instance.GetNamespace()}
 }
 
 func CreateWatcherDecisionEngineFromSample(sampleFileName string, name types.NamespacedName) types.NamespacedName {
 	raw := ReadSample(sampleFileName)
-	instance := CreateWatcherDecisionEngine(name, raw["spec"].(map[string]interface{}))
+	instance := CreateWatcherDecisionEngine(name, raw["spec"].(map[string]any))
 	DeferCleanup(th.DeleteInstance, instance)
 	return types.NamespacedName{Name: instance.GetName(), Namespace: instance.GetNamespace()}
 }

--- a/tests/functional/watcher_controller_test.go
+++ b/tests/functional/watcher_controller_test.go
@@ -27,11 +27,11 @@ import (
 )
 
 var (
-	MinimalWatcherSpec = map[string]interface{}{
+	MinimalWatcherSpec = map[string]any{
 		"databaseInstance": "openstack",
 	}
 
-	MinimalWatcherContainerSpec = map[string]interface{}{
+	MinimalWatcherContainerSpec = map[string]any{
 		"databaseInstance":                "openstack",
 		"apiContainerImageURL":            "watcher-api-custom-image",
 		"applierContainerImageURL":        "watcher-applier-custom-image",
@@ -711,10 +711,10 @@ var _ = Describe("Watcher controller", func() {
 			spec := GetDefaultWatcherAPISpec()
 			spec["databaseInstance"] = ""
 
-			raw := map[string]interface{}{
+			raw := map[string]any{
 				"apiVersion": "watcher.openstack.org/v1beta1",
 				"kind":       "watcher",
-				"metadata": map[string]interface{}{
+				"metadata": map[string]any{
 					"name":      watcherName.Name,
 					"namespace": watcherName.Namespace,
 				},
@@ -740,12 +740,12 @@ var _ = Describe("Watcher controller", func() {
 		It("should raise an error of wrong topology namespace", func() {
 
 			spec := GetDefaultWatcherAPISpec()
-			spec["topologyRef"] = map[string]interface{}{"name": "foo", "namespace": "bar"}
+			spec["topologyRef"] = map[string]any{"name": "foo", "namespace": "bar"}
 
-			raw := map[string]interface{}{
+			raw := map[string]any{
 				"apiVersion": "watcher.openstack.org/v1beta1",
 				"kind":       "watcher",
-				"metadata": map[string]interface{}{
+				"metadata": map[string]any{
 					"name":      watcherName.Name,
 					"namespace": watcherName.Namespace,
 				},
@@ -772,10 +772,10 @@ var _ = Describe("Watcher controller", func() {
 			spec := GetDefaultWatcherAPISpec()
 			spec["rabbitMqClusterName"] = ""
 
-			raw := map[string]interface{}{
+			raw := map[string]any{
 				"apiVersion": "watcher.openstack.org/v1beta1",
 				"kind":       "watcher",
-				"metadata": map[string]interface{}{
+				"metadata": map[string]any{
 					"name":      watcherName.Name,
 					"namespace": watcherName.Namespace,
 				},
@@ -1415,7 +1415,7 @@ var _ = Describe("Watcher controller", func() {
 		var topologyRefAlt topologyv1.TopoRef
 		var expectedTopologySpec []corev1.TopologySpreadConstraint
 		BeforeEach(func() {
-			var topologySpec map[string]interface{}
+			var topologySpec map[string]any
 			// Build the topology Spec
 			topologySpec, expectedTopologySpec = GetSampleTopologySpec("watcher-api")
 			_ = expectedTopologySpec
@@ -1432,8 +1432,8 @@ var _ = Describe("Watcher controller", func() {
 				topologySpec)
 
 			spec := GetNonDefaultWatcherSpec()
-			spec["topologyRef"] = map[string]interface{}{"name": topologyRefAlt.Name}
-			spec["apiServiceTemplate"] = map[string]interface{}{"topologyRef": map[string]interface{}{"name": topologyRefAPI.Name}}
+			spec["topologyRef"] = map[string]any{"name": topologyRefAlt.Name}
+			spec["apiServiceTemplate"] = map[string]any{"topologyRef": map[string]any{"name": topologyRefAPI.Name}}
 			DeferCleanup(th.DeleteInstance, CreateWatcher(watcherTest.Instance, spec))
 			DeferCleanup(k8sClient.Delete, ctx, CreateWatcherMessageBusSecret(watcherTest.Instance.Namespace, "rabbitmq-secret"))
 			memcachedSpec := memcachedv1.MemcachedSpec{

--- a/tests/functional/watcherapi_controller_test.go
+++ b/tests/functional/watcherapi_controller_test.go
@@ -19,7 +19,7 @@ import (
 )
 
 var (
-	MinimalWatcherAPISpec = map[string]interface{}{
+	MinimalWatcherAPISpec = map[string]any{
 		"secret":            "osp-secret",
 		"memcachedInstance": "memcached",
 	}
@@ -846,7 +846,7 @@ transport_url =`
 			mariadb.SimulateMariaDBDatabaseCompleted(watcherTest.WatcherDatabaseName)
 
 			spec := GetDefaultWatcherAPISpec()
-			spec["topologyRef"] = map[string]interface{}{"name": "foo"}
+			spec["topologyRef"] = map[string]any{"name": "foo"}
 			DeferCleanup(th.DeleteInstance, CreateWatcherAPI(watcherTest.WatcherAPI, spec))
 		})
 		It("points to a non existing topology CR", func() {
@@ -870,7 +870,7 @@ transport_url =`
 		var topologyRefAlt topologyv1.TopoRef
 		var expectedTopologySpec []corev1.TopologySpreadConstraint
 		BeforeEach(func() {
-			var topologySpec map[string]interface{}
+			var topologySpec map[string]any
 			// Build the topology Spec
 			topologySpec, expectedTopologySpec = GetSampleTopologySpec("watcher-api")
 			_ = expectedTopologySpec
@@ -904,7 +904,7 @@ transport_url =`
 					},
 				))
 			spec := GetDefaultWatcherAPISpec()
-			spec["topologyRef"] = map[string]interface{}{"name": topologyRefAPI.Name}
+			spec["topologyRef"] = map[string]any{"name": topologyRefAPI.Name}
 			DeferCleanup(th.DeleteInstance, CreateWatcherAPI(watcherTest.WatcherAPI, spec))
 			DeferCleanup(keystone.DeleteKeystoneAPI, keystone.CreateKeystoneAPI(watcherTest.WatcherAPI.Namespace))
 			memcachedSpec := memcachedv1.MemcachedSpec{

--- a/tests/functional/watcherapplier_controller_test.go
+++ b/tests/functional/watcherapplier_controller_test.go
@@ -19,7 +19,7 @@ import (
 )
 
 var (
-	MinimalWatcherApplierSpec = map[string]interface{}{
+	MinimalWatcherApplierSpec = map[string]any{
 		"secret":            "osp-secret",
 		"memcachedInstance": "memcached",
 	}
@@ -439,7 +439,7 @@ transport_url =`
 			DeferCleanup(infra.DeleteMemcached, infra.CreateMemcached(watcherTest.WatcherApplier.Namespace, MemcachedInstance, memcachedSpec))
 			infra.SimulateMemcachedReady(watcherTest.MemcachedNamespace)
 			spec := GetDefaultWatcherApplierSpec()
-			spec["topologyRef"] = map[string]interface{}{"name": "foo"}
+			spec["topologyRef"] = map[string]any{"name": "foo"}
 			DeferCleanup(th.DeleteInstance, CreateWatcherApplier(watcherTest.WatcherApplier, spec))
 		})
 		It("points to a non existing topology CR", func() {
@@ -463,7 +463,7 @@ transport_url =`
 		var topologyRefAlt topologyv1.TopoRef
 		var expectedTopologySpec []corev1.TopologySpreadConstraint
 		BeforeEach(func() {
-			var topologySpec map[string]interface{}
+			var topologySpec map[string]any
 			// Build the topology Spec
 			topologySpec, expectedTopologySpec = GetSampleTopologySpec("watcher-applier")
 			_ = expectedTopologySpec
@@ -482,7 +482,7 @@ transport_url =`
 			secret := CreateInternalTopLevelSecret()
 			DeferCleanup(k8sClient.Delete, ctx, secret)
 			spec := GetDefaultWatcherApplierSpec()
-			spec["topologyRef"] = map[string]interface{}{"name": topologyRefApplier.Name}
+			spec["topologyRef"] = map[string]any{"name": topologyRefApplier.Name}
 			DeferCleanup(th.DeleteInstance, CreateWatcherApplier(watcherTest.WatcherApplier, spec))
 			DeferCleanup(keystone.DeleteKeystoneAPI, keystone.CreateKeystoneAPI(watcherTest.WatcherApplier.Namespace))
 			memcachedSpec := memcachedv1.MemcachedSpec{

--- a/tests/functional/watcherdecisionengine_controller_test.go
+++ b/tests/functional/watcherdecisionengine_controller_test.go
@@ -19,7 +19,7 @@ import (
 )
 
 var (
-	MinimalWatcherDecisionEngineSpec = map[string]interface{}{
+	MinimalWatcherDecisionEngineSpec = map[string]any{
 		"secret":            "osp-secret",
 		"memcachedInstance": "memcached",
 	}
@@ -388,7 +388,7 @@ transport_url =`
 			DeferCleanup(infra.DeleteMemcached, infra.CreateMemcached(watcherTest.WatcherDecisionEngine.Namespace, MemcachedInstance, memcachedSpec))
 			infra.SimulateMemcachedReady(watcherTest.MemcachedNamespace)
 			spec := GetDefaultWatcherDecisionEngineSpec()
-			spec["topologyRef"] = map[string]interface{}{"name": "foo"}
+			spec["topologyRef"] = map[string]any{"name": "foo"}
 			DeferCleanup(th.DeleteInstance, CreateWatcherDecisionEngine(watcherTest.WatcherDecisionEngine, spec))
 		})
 		It("points to a non existing topology CR", func() {
@@ -412,7 +412,7 @@ transport_url =`
 		var topologyRefAlt topologyv1.TopoRef
 		var expectedTopologySpec []corev1.TopologySpreadConstraint
 		BeforeEach(func() {
-			var topologySpec map[string]interface{}
+			var topologySpec map[string]any
 			// Build the topology Spec
 			topologySpec, expectedTopologySpec = GetSampleTopologySpec("watcher-decision-engine")
 			_ = expectedTopologySpec
@@ -439,7 +439,7 @@ transport_url =`
 			)
 			DeferCleanup(k8sClient.Delete, ctx, prometheusSecret)
 			spec := GetDefaultWatcherDecisionEngineSpec()
-			spec["topologyRef"] = map[string]interface{}{"name": topologyRefDecEng.Name}
+			spec["topologyRef"] = map[string]any{"name": topologyRefDecEng.Name}
 			DeferCleanup(th.DeleteInstance, CreateWatcherDecisionEngine(watcherTest.WatcherDecisionEngine, spec))
 			DeferCleanup(keystone.DeleteKeystoneAPI, keystone.CreateKeystoneAPI(watcherTest.WatcherDecisionEngine.Namespace))
 			memcachedSpec := memcachedv1.MemcachedSpec{


### PR DESCRIPTION
Modernize using `gopls modernize tool` to update:

- Replace interface{} with any type alias (Go 1.18+)
- Update range loops to use idiomatic range syntax
- Replace fmt.Sprintf with fmt.Appendf where appropriate

These changes improve code readability and align with current Go best practices.

Co-Authored-By: Claude <noreply@anthropic.com>