### PR TITLE
Use content provider service containers in kuttl

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -104,6 +104,9 @@
       fetch_dlrn_hash: false
       deploy_watcher_operator_extra_vars:
         watcher_catalog_image: "{{ cifmw_operator_build_output['operators']['watcher-operator'].image_catalog }}"
+        # use master content for watcher services
+        content_provider_os_registry_url: "{{ content_provider_os_registry_url }}"
+        watcher_services_tag: watcher_latest
       cifmw_extras:
         - "@{{ ansible_user_dir }}/{{ zuul.projects['github.com/openstack-k8s-operators/watcher-operator'].
            src_dir }}/ci/scenarios/kuttl.yml"
@@ -113,8 +116,6 @@
       # var. As returned dlrn md5 hash comes from master release but job is using
       # antelope content.
       content_provider_dlrn_md5_hash: ''
-      # We also need to override the registry otherwise kuttl test will fail
-      content_provider_os_registry_url: "quay.io/podified-master-centos9"
 
 - job:
     name: watcher-operator-doc-preview

--- a/tests/kuttl/test-suites/default/watcher-api-scaling/01-assert.yaml
+++ b/tests/kuttl/test-suites/default/watcher-api-scaling/01-assert.yaml
@@ -6,9 +6,6 @@ metadata:
   name: watcher-kuttl
   namespace: watcher-kuttl-default
 spec:
-  apiContainerImageURL: "quay.io/podified-master-centos9/openstack-watcher-api:current-podified"
-  decisionengineContainerImageURL: "quay.io/podified-master-centos9/openstack-watcher-decision-engine:current-podified"
-  applierContainerImageURL: "quay.io/podified-master-centos9/openstack-watcher-applier:current-podified"
   databaseAccount: watcher
   databaseInstance: openstack
   passwordSelectors:
@@ -214,7 +211,6 @@ metadata:
   - openstack.org/watcherapi
   name: watcher-kuttl-api
 spec:
-  containerImage: quay.io/podified-master-centos9/openstack-watcher-api:current-podified
   memcachedInstance: memcached
   passwordSelectors:
     service: WatcherPassword
@@ -350,7 +346,6 @@ metadata:
   - openstack.org/watcherapplier
   name: watcher-kuttl-applier
 spec:
-  containerImage: quay.io/podified-master-centos9/openstack-watcher-applier:current-podified
   memcachedInstance: memcached
   passwordSelectors:
     service: WatcherPassword
@@ -395,7 +390,6 @@ spec:
     spec:
       containers:
       - name: watcher-applier
-        image: quay.io/podified-master-centos9/openstack-watcher-applier:current-podified
 status:
   readyReplicas: 1
   replicas: 1
@@ -409,7 +403,6 @@ metadata:
 spec:
   containers:
   - name: watcher-applier
-    image: quay.io/podified-master-centos9/openstack-watcher-applier:current-podified
 status:
   phase: Running
 ---
@@ -420,7 +413,6 @@ metadata:
   - openstack.org/watcherdecisionengine
   name: watcher-kuttl-decision-engine
 spec:
-  containerImage: quay.io/podified-master-centos9/openstack-watcher-decision-engine:current-podified
   memcachedInstance: memcached
   passwordSelectors:
     service: WatcherPassword
@@ -465,7 +457,6 @@ spec:
     spec:
       containers:
       - name: watcher-decision-engine
-        image: quay.io/podified-master-centos9/openstack-watcher-decision-engine:current-podified
 status:
   readyReplicas: 1
   replicas: 1
@@ -479,7 +470,6 @@ metadata:
 spec:
   containers:
   - name: watcher-decision-engine
-    image: quay.io/podified-master-centos9/openstack-watcher-decision-engine:current-podified
 status:
   phase: Running
 ---

--- a/tests/kuttl/test-suites/default/watcher-api-scaling/01-deploy-with-defaults.yaml
+++ b/tests/kuttl/test-suites/default/watcher-api-scaling/01-deploy-with-defaults.yaml
@@ -6,4 +6,6 @@ metadata:
 spec:
   databaseInstance: "openstack"
   apiServiceTemplate:
+    tls:
+      caBundleSecretName: "combined-ca-bundle"
     replicas: 2

--- a/tests/kuttl/test-suites/default/watcher-notification/01-assert.yaml
+++ b/tests/kuttl/test-suites/default/watcher-notification/01-assert.yaml
@@ -217,7 +217,6 @@ spec:
               value: COPY_ALWAYS
             - name: PURGE_AGE
               value: "90"
-            image: quay.io/podified-master-centos9/openstack-watcher-api:current-podified
           serviceAccount: watcher-watcher-kuttl
   schedule: "0 1 * * *"
 ---
@@ -228,7 +227,6 @@ metadata:
   - openstack.org/watcherapi
   name: watcher-kuttl-api
 spec:
-  containerImage: quay.io/podified-master-centos9/openstack-watcher-api:current-podified
   memcachedInstance: memcached
   passwordSelectors:
     service: WatcherPassword
@@ -311,7 +309,6 @@ metadata:
   - openstack.org/watcherapplier
   name: watcher-kuttl-applier
 spec:
-  containerImage: quay.io/podified-master-centos9/openstack-watcher-applier:current-podified
   memcachedInstance: memcached
   passwordSelectors:
     service: WatcherPassword
@@ -356,7 +353,6 @@ spec:
     spec:
       containers:
       - name: watcher-applier
-        image: quay.io/podified-master-centos9/openstack-watcher-applier:current-podified
 status:
   readyReplicas: 1
   replicas: 1
@@ -370,7 +366,6 @@ metadata:
 spec:
   containers:
   - name: watcher-applier
-    image: quay.io/podified-master-centos9/openstack-watcher-applier:current-podified
 status:
   phase: Running
 ---
@@ -381,7 +376,6 @@ metadata:
   - openstack.org/watcherdecisionengine
   name: watcher-kuttl-decision-engine
 spec:
-  containerImage: quay.io/podified-master-centos9/openstack-watcher-decision-engine:current-podified
   memcachedInstance: memcached
   passwordSelectors:
     service: WatcherPassword
@@ -426,7 +420,6 @@ spec:
     spec:
       containers:
       - name: watcher-decision-engine
-        image: quay.io/podified-master-centos9/openstack-watcher-decision-engine:current-podified
 status:
   readyReplicas: 1
   replicas: 1
@@ -440,7 +433,6 @@ metadata:
 spec:
   containers:
   - name: watcher-decision-engine
-    image: quay.io/podified-master-centos9/openstack-watcher-decision-engine:current-podified
 status:
   phase: Running
 ---

--- a/tests/kuttl/test-suites/default/watcher-tls-certs-change/01-assert.yaml
+++ b/tests/kuttl/test-suites/default/watcher-tls-certs-change/01-assert.yaml
@@ -5,9 +5,6 @@ metadata:
   - openstack.org/watcher
   name: watcher-kuttl
 spec:
-  apiContainerImageURL: "quay.io/podified-master-centos9/openstack-watcher-api:current-podified"
-  decisionengineContainerImageURL: "quay.io/podified-master-centos9/openstack-watcher-decision-engine:current-podified"
-  applierContainerImageURL: "quay.io/podified-master-centos9/openstack-watcher-applier:current-podified"
   databaseAccount: watcher
   databaseInstance: openstack
   passwordSelectors:
@@ -215,7 +212,6 @@ metadata:
   - openstack.org/watcherapi
   name: watcher-kuttl-api
 spec:
-  containerImage: quay.io/podified-master-centos9/openstack-watcher-api:current-podified
   memcachedInstance: memcached
   passwordSelectors:
     service: WatcherPassword
@@ -345,7 +341,6 @@ metadata:
   - openstack.org/watcherapplier
   name: watcher-kuttl-applier
 spec:
-  containerImage: quay.io/podified-master-centos9/openstack-watcher-applier:current-podified
   memcachedInstance: memcached
   passwordSelectors:
     service: WatcherPassword
@@ -390,7 +385,6 @@ spec:
     spec:
       containers:
       - name: watcher-applier
-        image: quay.io/podified-master-centos9/openstack-watcher-applier:current-podified
 status:
   readyReplicas: 1
   replicas: 1
@@ -404,7 +398,6 @@ metadata:
 spec:
   containers:
   - name: watcher-applier
-    image: quay.io/podified-master-centos9/openstack-watcher-applier:current-podified
 status:
   phase: Running
 ---
@@ -415,7 +408,6 @@ metadata:
   - openstack.org/watcherdecisionengine
   name: watcher-kuttl-decision-engine
 spec:
-  containerImage: quay.io/podified-master-centos9/openstack-watcher-decision-engine:current-podified
   memcachedInstance: memcached
   passwordSelectors:
     service: WatcherPassword
@@ -460,7 +452,6 @@ spec:
     spec:
       containers:
       - name: watcher-decision-engine
-        image: quay.io/podified-master-centos9/openstack-watcher-decision-engine:current-podified
 status:
   readyReplicas: 1
   replicas: 1
@@ -474,7 +465,6 @@ metadata:
 spec:
   containers:
   - name: watcher-decision-engine
-    image: quay.io/podified-master-centos9/openstack-watcher-decision-engine:current-podified
 status:
   phase: Running
 ---

--- a/tests/kuttl/test-suites/default/watcher-tls/01-assert.yaml
+++ b/tests/kuttl/test-suites/default/watcher-tls/01-assert.yaml
@@ -5,9 +5,6 @@ metadata:
   - openstack.org/watcher
   name: watcher-kuttl
 spec:
-  apiContainerImageURL: "quay.io/podified-master-centos9/openstack-watcher-api:current-podified"
-  decisionengineContainerImageURL: "quay.io/podified-master-centos9/openstack-watcher-decision-engine:current-podified"
-  applierContainerImageURL: "quay.io/podified-master-centos9/openstack-watcher-applier:current-podified"
   databaseAccount: watcher
   databaseInstance: openstack
   passwordSelectors:
@@ -215,7 +212,6 @@ metadata:
   - openstack.org/watcherapi
   name: watcher-kuttl-api
 spec:
-  containerImage: quay.io/podified-master-centos9/openstack-watcher-api:current-podified
   memcachedInstance: memcached
   passwordSelectors:
     service: WatcherPassword
@@ -345,7 +341,6 @@ metadata:
   - openstack.org/watcherapplier
   name: watcher-kuttl-applier
 spec:
-  containerImage: quay.io/podified-master-centos9/openstack-watcher-applier:current-podified
   memcachedInstance: memcached
   passwordSelectors:
     service: WatcherPassword
@@ -390,7 +385,6 @@ spec:
     spec:
       containers:
       - name: watcher-applier
-        image: quay.io/podified-master-centos9/openstack-watcher-applier:current-podified
 status:
   readyReplicas: 1
   replicas: 1
@@ -404,7 +398,6 @@ metadata:
 spec:
   containers:
   - name: watcher-applier
-    image: quay.io/podified-master-centos9/openstack-watcher-applier:current-podified
 status:
   phase: Running
 ---
@@ -415,7 +408,6 @@ metadata:
   - openstack.org/watcherdecisionengine
   name: watcher-kuttl-decision-engine
 spec:
-  containerImage: quay.io/podified-master-centos9/openstack-watcher-decision-engine:current-podified
   memcachedInstance: memcached
   passwordSelectors:
     service: WatcherPassword
@@ -460,7 +452,6 @@ spec:
     spec:
       containers:
       - name: watcher-decision-engine
-        image: quay.io/podified-master-centos9/openstack-watcher-decision-engine:current-podified
 status:
   readyReplicas: 1
   replicas: 1
@@ -474,7 +465,6 @@ metadata:
 spec:
   containers:
   - name: watcher-decision-engine
-    image: quay.io/podified-master-centos9/openstack-watcher-decision-engine:current-podified
 status:
   phase: Running
 ---

--- a/tests/kuttl/test-suites/default/watcher-tls/03-assert.yaml
+++ b/tests/kuttl/test-suites/default/watcher-tls/03-assert.yaml
@@ -5,9 +5,6 @@ metadata:
   - openstack.org/watcher
   name: watcher-kuttl
 spec:
-  apiContainerImageURL: "quay.io/podified-master-centos9/openstack-watcher-api:current-podified"
-  decisionengineContainerImageURL: "quay.io/podified-master-centos9/openstack-watcher-decision-engine:current-podified"
-  applierContainerImageURL: "quay.io/podified-master-centos9/openstack-watcher-applier:current-podified"
   databaseAccount: watcher
   databaseInstance: openstack
   passwordSelectors:
@@ -95,7 +92,6 @@ metadata:
   - openstack.org/watcherapi
   name: watcher-kuttl-api
 spec:
-  containerImage: quay.io/podified-master-centos9/openstack-watcher-api:current-podified
   memcachedInstance: memcached
   passwordSelectors:
     service: WatcherPassword

--- a/tests/kuttl/test-suites/default/watcher-tls/04-assert.yaml
+++ b/tests/kuttl/test-suites/default/watcher-tls/04-assert.yaml
@@ -5,9 +5,6 @@ metadata:
   - openstack.org/watcher
   name: watcher-kuttl
 spec:
-  apiContainerImageURL: "quay.io/podified-master-centos9/openstack-watcher-api:current-podified"
-  decisionengineContainerImageURL: "quay.io/podified-master-centos9/openstack-watcher-decision-engine:current-podified"
-  applierContainerImageURL: "quay.io/podified-master-centos9/openstack-watcher-applier:current-podified"
   databaseAccount: watcher
   databaseInstance: openstack
   passwordSelectors:
@@ -193,7 +190,6 @@ metadata:
   - openstack.org/watcherapi
   name: watcher-kuttl-api
 spec:
-  containerImage: quay.io/podified-master-centos9/openstack-watcher-api:current-podified
   memcachedInstance: memcached
   passwordSelectors:
     service: WatcherPassword

--- a/tests/kuttl/test-suites/default/watcher-tls/05-assert.yaml
+++ b/tests/kuttl/test-suites/default/watcher-tls/05-assert.yaml
@@ -5,9 +5,6 @@ metadata:
   - openstack.org/watcher
   name: watcher-kuttl
 spec:
-  apiContainerImageURL: "quay.io/podified-master-centos9/openstack-watcher-api:current-podified"
-  decisionengineContainerImageURL: "quay.io/podified-master-centos9/openstack-watcher-decision-engine:current-podified"
-  applierContainerImageURL: "quay.io/podified-master-centos9/openstack-watcher-applier:current-podified"
   databaseAccount: watcher
   databaseInstance: openstack
   passwordSelectors:
@@ -95,7 +92,6 @@ metadata:
   - openstack.org/watcherapi
   name: watcher-kuttl-api
 spec:
-  containerImage: quay.io/podified-master-centos9/openstack-watcher-api:current-podified
   memcachedInstance: memcached
   passwordSelectors:
     service: WatcherPassword

--- a/tests/kuttl/test-suites/default/watcher-topology/01-assert.yaml
+++ b/tests/kuttl/test-suites/default/watcher-topology/01-assert.yaml
@@ -6,9 +6,6 @@ metadata:
   name: watcher-kuttl
   namespace: watcher-kuttl-default
 spec:
-  apiContainerImageURL: "quay.io/podified-master-centos9/openstack-watcher-api:current-podified"
-  decisionengineContainerImageURL: "quay.io/podified-master-centos9/openstack-watcher-decision-engine:current-podified"
-  applierContainerImageURL: "quay.io/podified-master-centos9/openstack-watcher-applier:current-podified"
   databaseAccount: watcher
   databaseInstance: openstack
   passwordSelectors:
@@ -105,7 +102,6 @@ metadata:
   - openstack.org/watcherapi
   name: watcher-kuttl-api
 spec:
-  containerImage: quay.io/podified-master-centos9/openstack-watcher-api:current-podified
   memcachedInstance: memcached
   passwordSelectors:
     service: WatcherPassword

--- a/tests/kuttl/test-suites/default/watcher/01-assert.yaml
+++ b/tests/kuttl/test-suites/default/watcher/01-assert.yaml
@@ -6,9 +6,6 @@ metadata:
   name: watcher-kuttl
   namespace: watcher-kuttl-default
 spec:
-  apiContainerImageURL: "quay.io/podified-master-centos9/openstack-watcher-api:current-podified"
-  decisionengineContainerImageURL: "quay.io/podified-master-centos9/openstack-watcher-decision-engine:current-podified"
-  applierContainerImageURL: "quay.io/podified-master-centos9/openstack-watcher-applier:current-podified"
   databaseAccount: watcher
   databaseInstance: openstack
   passwordSelectors:
@@ -242,7 +239,6 @@ spec:
               value: COPY_ALWAYS
             - name: PURGE_AGE
               value: "90"
-            image: quay.io/podified-master-centos9/openstack-watcher-api:current-podified
           serviceAccount: watcher-watcher-kuttl
   schedule: 0 1 * * *
 ---
@@ -253,7 +249,6 @@ metadata:
   - openstack.org/watcherapi
   name: watcher-kuttl-api
 spec:
-  containerImage: quay.io/podified-master-centos9/openstack-watcher-api:current-podified
   memcachedInstance: memcached
   passwordSelectors:
     service: WatcherPassword
@@ -376,7 +371,6 @@ metadata:
   - openstack.org/watcherapplier
   name: watcher-kuttl-applier
 spec:
-  containerImage: quay.io/podified-master-centos9/openstack-watcher-applier:current-podified
   memcachedInstance: memcached
   passwordSelectors:
     service: WatcherPassword
@@ -421,7 +415,6 @@ spec:
     spec:
       containers:
       - name: watcher-applier
-        image: quay.io/podified-master-centos9/openstack-watcher-applier:current-podified
 status:
   readyReplicas: 1
   replicas: 1
@@ -435,7 +428,6 @@ metadata:
 spec:
   containers:
   - name: watcher-applier
-    image: quay.io/podified-master-centos9/openstack-watcher-applier:current-podified
 status:
   phase: Running
 ---
@@ -446,7 +438,6 @@ metadata:
   - openstack.org/watcherdecisionengine
   name: watcher-kuttl-decision-engine
 spec:
-  containerImage: quay.io/podified-master-centos9/openstack-watcher-decision-engine:current-podified
   memcachedInstance: memcached
   passwordSelectors:
     service: WatcherPassword
@@ -491,7 +482,6 @@ spec:
     spec:
       containers:
       - name: watcher-decision-engine
-        image: quay.io/podified-master-centos9/openstack-watcher-decision-engine:current-podified
 status:
   readyReplicas: 1
   replicas: 1
@@ -505,7 +495,6 @@ metadata:
 spec:
   containers:
   - name: watcher-decision-engine
-    image: quay.io/podified-master-centos9/openstack-watcher-decision-engine:current-podified
 status:
   phase: Running
 ---

--- a/tests/kuttl/test-suites/default/watcher/04-assert.yaml
+++ b/tests/kuttl/test-suites/default/watcher/04-assert.yaml
@@ -219,7 +219,6 @@ spec:
               value: COPY_ALWAYS
             - name: PURGE_AGE
               value: "1"
-            image: quay.io/podified-master-centos9/openstack-watcher-api:current-podified
           serviceAccount: watcher-watcher-kuttl
   schedule: "* * * * *"
 ---
@@ -244,7 +243,6 @@ metadata:
   - openstack.org/watcherapi
   name: watcher-kuttl-api
 spec:
-  containerImage: quay.io/podified-master-centos9/openstack-watcher-api:current-podified
   memcachedInstance: memcached
   passwordSelectors:
     service: WatcherPassword
@@ -340,7 +338,6 @@ metadata:
   - openstack.org/watcherapplier
   name: watcher-kuttl-applier
 spec:
-  containerImage: quay.io/podified-master-centos9/openstack-watcher-applier:current-podified
   memcachedInstance: memcached
   passwordSelectors:
     service: WatcherPassword
@@ -385,7 +382,6 @@ spec:
     spec:
       containers:
       - name: watcher-applier
-        image: quay.io/podified-master-centos9/openstack-watcher-applier:current-podified
 status:
   readyReplicas: 1
   replicas: 1
@@ -399,7 +395,6 @@ metadata:
 spec:
   containers:
   - name: watcher-applier
-    image: quay.io/podified-master-centos9/openstack-watcher-applier:current-podified
 status:
   phase: Running
 ---
@@ -410,7 +405,6 @@ metadata:
   - openstack.org/watcherdecisionengine
   name: watcher-kuttl-decision-engine
 spec:
-  containerImage: quay.io/podified-master-centos9/openstack-watcher-decision-engine:current-podified
   memcachedInstance: memcached
   passwordSelectors:
     service: WatcherPassword
@@ -455,7 +449,6 @@ spec:
     spec:
       containers:
       - name: watcher-decision-engine
-        image: quay.io/podified-master-centos9/openstack-watcher-decision-engine:current-podified
 status:
   readyReplicas: 1
   replicas: 1
@@ -469,7 +462,6 @@ metadata:
 spec:
   containers:
   - name: watcher-decision-engine
-    image: quay.io/podified-master-centos9/openstack-watcher-decision-engine:current-podified
 status:
   phase: Running
 ---

--- a/tests/kuttl/test-suites/default/watcher/04-deploy-with-precreated-account.yaml
+++ b/tests/kuttl/test-suites/default/watcher/04-deploy-with-precreated-account.yaml
@@ -18,11 +18,11 @@ spec:
   databaseInstance: "openstack"
   databaseAccount: watcher-precreated
   prometheusSecret: custom-prometheus-config
-  tls:
-    caBundleSecretName: "combined-ca-bundle"
   customServiceConfig: |
     # Global config
   apiServiceTemplate:
+    tls:
+      caBundleSecretName: "combined-ca-bundle"
     replicas: 2
     customServiceConfig: |
       # Service config


### PR DESCRIPTION
Consume the watcher service container images from the content provider
job in the kuttl job.

Remove the checks for the container images in the kuttl asserts.

Fix tls field in watcher kuttl test suite

The kuttl test suite had a misplaced caBundleSecretName field. This was
not detected before because even though the pods could not communicated
properly with keystone or rabbitmq, they kept running. After switching
to containers built from watcher master, the decision engine tries to
connect to keystone and fails, crashing.