### PR TITLE
[OSPRH-20473] Improve consistency of condition severity usage

### DIFF
--- a/controllers/watcher_controller.go
+++ b/controllers/watcher_controller.go
@@ -219,7 +219,7 @@ func (r *WatcherReconciler) Reconcile(ctx context.Context, req ctrl.Request) (re
 		Log.Info(fmt.Sprintf("Waiting for TransportURL for %s to be created", instance.Name))
 		instance.Status.Conditions.Set(condition.FalseCondition(
 			watcherv1beta1.WatcherRabbitMQTransportURLReadyCondition,
-			condition.RequestedReason,
+			condition.ErrorReason,
 			condition.SeverityWarning,
 			watcherv1beta1.WatcherRabbitMQTransportURLReadyRunningMessage))
 		return ctrl.Result{RequeueAfter: time.Duration(10) * time.Second}, nil
@@ -333,7 +333,7 @@ func (r *WatcherReconciler) Reconcile(ctx context.Context, req ctrl.Request) (re
 		// Empty hash means that there is some problem retrieving the key from the secret
 		instance.Status.Conditions.Set(condition.FalseCondition(
 			condition.InputReadyCondition,
-			condition.RequestedReason,
+			condition.ErrorReason,
 			condition.SeverityWarning,
 			watcherv1beta1.WatcherPrometheusSecretErrorMessage))
 		return ctrl.Result{}, ErrRetrievingPrometheusSecretData
@@ -345,7 +345,7 @@ func (r *WatcherReconciler) Reconcile(ctx context.Context, req ctrl.Request) (re
 		if err != nil {
 			instance.Status.Conditions.Set(condition.FalseCondition(
 				condition.InputReadyCondition,
-				condition.RequestedReason,
+				condition.ErrorReason,
 				condition.SeverityWarning,
 				watcherv1beta1.WatcherPrometheusSecretErrorMessage))
 			return ctrl.Result{}, err

--- a/controllers/watcherapi_controller.go
+++ b/controllers/watcherapi_controller.go
@@ -201,7 +201,7 @@ func (r *WatcherAPIReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 		// Empty hash means that there is some problem retrieving the key from the secret
 		instance.Status.Conditions.Set(condition.FalseCondition(
 			condition.InputReadyCondition,
-			condition.RequestedReason,
+			condition.ErrorReason,
 			condition.SeverityWarning,
 			watcherv1beta1.WatcherPrometheusSecretErrorMessage))
 		return ctrl.Result{}, ErrRetrievingPrometheusSecretData
@@ -276,10 +276,12 @@ func (r *WatcherAPIReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 		)
 		if err != nil {
 			if k8s_errors.IsNotFound(err) {
+				// Since the CA cert secret should have been manually created by the user and provided in the spec,
+				// we treat this as a warning because it means that the service will not be able to start.
 				instance.Status.Conditions.Set(condition.FalseCondition(
 					condition.TLSInputReadyCondition,
-					condition.RequestedReason,
-					condition.SeverityInfo,
+					condition.ErrorReason,
+					condition.SeverityWarning,
 					condition.TLSInputReadyWaitingMessage, instance.Spec.TLS.CaBundleSecretName,
 				))
 				return ctrl.Result{}, nil

--- a/controllers/watcherdecisionengine_controller.go
+++ b/controllers/watcherdecisionengine_controller.go
@@ -194,7 +194,7 @@ func (r *WatcherDecisionEngineReconciler) Reconcile(ctx context.Context, req ctr
 		// Empty hash means that there is some problem retrieving the key from the secret
 		instance.Status.Conditions.Set(condition.FalseCondition(
 			condition.InputReadyCondition,
-			condition.RequestedReason,
+			condition.ErrorReason,
 			condition.SeverityWarning,
 			watcherv1beta1.WatcherPrometheusSecretErrorMessage))
 		return ctrl.Result{}, ErrRetrievingPrometheusSecretData

--- a/tests/functional/watcher_controller_test.go
+++ b/tests/functional/watcher_controller_test.go
@@ -556,7 +556,7 @@ var _ = Describe("Watcher controller", func() {
 				ConditionGetterFunc(WatcherConditionGetter),
 				condition.InputReadyCondition,
 				corev1.ConditionFalse,
-				condition.RequestedReason,
+				condition.ErrorReason,
 				"Input data resources missing",
 			)
 
@@ -1195,7 +1195,7 @@ var _ = Describe("Watcher controller", func() {
 				ConditionGetterFunc(WatcherConditionGetter),
 				condition.InputReadyCondition,
 				corev1.ConditionFalse,
-				condition.RequestedReason,
+				condition.ErrorReason,
 				"Error with prometheus config secret",
 			)
 		})

--- a/tests/functional/watcherapi_controller_test.go
+++ b/tests/functional/watcherapi_controller_test.go
@@ -372,7 +372,7 @@ transport_url =`
 				ConditionGetterFunc(WatcherAPIConditionGetter),
 				condition.InputReadyCondition,
 				corev1.ConditionFalse,
-				condition.RequestedReason,
+				condition.ErrorReason,
 				condition.InputReadyWaitingMessage,
 			)
 		})
@@ -406,7 +406,7 @@ transport_url =`
 				ConditionGetterFunc(WatcherAPIConditionGetter),
 				condition.MemcachedReadyCondition,
 				corev1.ConditionFalse,
-				condition.RequestedReason,
+				condition.ErrorReason,
 				condition.MemcachedReadyWaitingMessage,
 			)
 		})
@@ -425,7 +425,7 @@ transport_url =`
 				ConditionGetterFunc(WatcherAPIConditionGetter),
 				condition.InputReadyCondition,
 				corev1.ConditionFalse,
-				condition.RequestedReason,
+				condition.ErrorReason,
 				watcherv1beta1.WatcherPrometheusSecretErrorMessage,
 			)
 		})

--- a/tests/functional/watcherapplier_controller_test.go
+++ b/tests/functional/watcherapplier_controller_test.go
@@ -325,7 +325,7 @@ transport_url =`
 				ConditionGetterFunc(WatcherApplierConditionGetter),
 				condition.InputReadyCondition,
 				corev1.ConditionFalse,
-				condition.RequestedReason,
+				condition.ErrorReason,
 				condition.InputReadyWaitingMessage,
 			)
 		})
@@ -351,7 +351,7 @@ transport_url =`
 				ConditionGetterFunc(WatcherApplierConditionGetter),
 				condition.MemcachedReadyCondition,
 				corev1.ConditionFalse,
-				condition.RequestedReason,
+				condition.ErrorReason,
 				condition.MemcachedReadyWaitingMessage,
 			)
 		})


### PR DESCRIPTION
Use consistent condition severity across repeated patterns found in our operators, and otherwise use an appropriate severity for conditions unique to each operator.

Jira: https://issues.redhat.com/browse/OSPRH-20473

Co-authored-by: Claude (Anthropic) claude@anthropic.com