### PR TITLE
Move rabbitmq notifications queue to controlplane level

### DIFF
--- a/ci/scenarios/edpm.yml
+++ b/ci/scenarios/edpm.yml
@@ -63,20 +63,7 @@ cifmw_edpm_prepare_kustomizations:
           metadata:
             name: controlplane
           spec:
-            nova:
-              template:
-                notificationsBusInstance: rabbitmq-notifications
-        target:
-          kind: OpenStackControlPlane
-      - patch: |-
-          apiVersion: core.openstack.org/v1beta1
-          kind: OpenStackControlPlane
-          metadata:
-            name: controlplane
-          spec:
-            cinder:
-              template:
-                notificationsBusInstance: rabbitmq-notifications
+            notificationsBusInstance: rabbitmq-notifications
         target:
           kind: OpenStackControlPlane
       - patch: |-
@@ -88,7 +75,6 @@ cifmw_edpm_prepare_kustomizations:
             rabbitmq:
               templates:
                 rabbitmq-notifications:
-                  delayStartSeconds: 30
                   override:
                     service:
                       metadata:
@@ -107,10 +93,9 @@ cifmw_edpm_prepare_kustomizations:
           spec:
             watcher:
               enabled: true
-              template:
-                notificationsBusInstance: rabbitmq-notifications
         target:
           kind: OpenStackControlPlane
+
 
 cifmw_edpm_prepare_timeout: 60
 


### PR DESCRIPTION
Move rabbitmq notifications queue from enabling at nova/cinder/watcher level to openstack controlplane level after that usage is available since https://github.com/openstack-k8s-operators/openstack-operator/pull/1591.

`delayStartSeconds` parameter removed from rabbitmq notifications queue creation because it is not necessary, it is automatically added by controlplane when creating a new queue
