### PR TITLE
Set max_workers=8 in [watcher_workflow_engines.taskflow] config section

### DIFF
--- a/templates/00-default.conf
+++ b/templates/00-default.conf
@@ -174,6 +174,9 @@ interface = internal
 region_name = {{ .Region }}
 {{- end }}
 
+[watcher_workflow_engines.taskflow]
+max_workers = 8
+
 [watcher_cluster_data_model_collectors.compute]
 period = 900
 

--- a/test/functional/watcherapi_controller_test.go
+++ b/test/functional/watcherapi_controller_test.go
@@ -293,6 +293,8 @@ region_name = regionOne`, `
 [placement_client]
 interface = internal
 region_name = regionOne`, `
+[watcher_workflow_engines.taskflow]
+max_workers = 8`, `
 [watcher_cluster_data_model_collectors.compute]
 period = 900`, `
 [watcher_cluster_data_model_collectors.baremetal]
@@ -1200,6 +1202,8 @@ region_name = regionTwo`, `
 [placement_client]
 interface = internal
 region_name = regionTwo`, `
+[watcher_workflow_engines.taskflow]
+max_workers = 8`, `
 [watcher_cluster_data_model_collectors.compute]
 period = 900`, `
 [watcher_cluster_data_model_collectors.baremetal]

--- a/test/functional/watcherapplier_controller_test.go
+++ b/test/functional/watcherapplier_controller_test.go
@@ -217,6 +217,8 @@ region_name = regionOne`, `
 [placement_client]
 interface = internal
 region_name = regionOne`, `
+[watcher_workflow_engines.taskflow]
+max_workers = 8`, `
 [oslo_messaging_notifications]
 
 driver = noop`,
@@ -778,6 +780,8 @@ region_name = regionTwo`, `
 [placement_client]
 interface = internal
 region_name = regionTwo`, `
+[watcher_workflow_engines.taskflow]
+max_workers = 8`, `
 [oslo_messaging_notifications]
 
 driver = messagingv2

--- a/test/functional/watcherdecisionengine_controller_test.go
+++ b/test/functional/watcherdecisionengine_controller_test.go
@@ -227,6 +227,8 @@ region_name = regionOne`, `
 [placement_client]
 interface = internal
 region_name = regionOne`, `
+[watcher_workflow_engines.taskflow]
+max_workers = 8`, `
 [watcher_cluster_data_model_collectors.compute]
 period = 900`, `
 [watcher_cluster_data_model_collectors.baremetal]
@@ -747,6 +749,8 @@ region_name = regionTwo`, `
 [placement_client]
 interface = internal
 region_name = regionTwo`, `
+[watcher_workflow_engines.taskflow]
+max_workers = 8`, `
 [watcher_cluster_data_model_collectors.compute]
 period = 900`, `
 [watcher_cluster_data_model_collectors.baremetal]

--- a/test/kuttl/test-suites/default/watcher-tls/01-assert.yaml
+++ b/test/kuttl/test-suites/default/watcher-tls/01-assert.yaml
@@ -481,6 +481,7 @@ commands:
       [ -n "$(oc get -n ${NAMESPACE} watcher watcher-kuttl -o jsonpath={.status.hash.dbsync})" ]
       [ "$(oc get -n ${NAMESPACE} secret watcher-kuttl-api-config-data -o jsonpath='{.data.my\.cnf}'|base64 -d|grep -c 'ssl=1')" == 1 ]
       [ "$(oc get -n ${NAMESPACE} secret watcher-kuttl-api-config-data -o jsonpath='{.data.00-default\.conf}'|base64 -d|grep -c 'cafile = /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem')" == 2 ]
+      [ "$(oc get -n ${NAMESPACE} secret watcher-kuttl-api-config-data -o jsonpath='{.data.00-default\.conf}'|base64 -d|grep -c 'max_workers = 8')" == 1 ]
       # check that both endpoints have https set
       oc exec -n ${NAMESPACE} openstackclient -- openstack endpoint list | grep infra-optim | [ $(grep -c https) == 2 ]
       # If we are running the container locally, skip following test

--- a/test/kuttl/test-suites/default/watcher/01-assert.yaml
+++ b/test/kuttl/test-suites/default/watcher/01-assert.yaml
@@ -512,6 +512,7 @@ commands:
       [ "$(oc get -n watcher-kuttl-default secret watcher-kuttl-api-config-data -o jsonpath='{.data.my\.cnf}'|base64 -d|grep -c 'ssl=1')" == 1 ]
       [ "$(oc get -n watcher-kuttl-default secret watcher-kuttl-api-config-data -o jsonpath='{.data.00-default\.conf}'|base64 -d|grep -c 'cafile = /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem')" == 2 ]
       [ "$(oc get -n watcher-kuttl-default secret watcher-kuttl-api-config-data -o jsonpath='{.data.00-default\.conf}'|base64 -d|grep -c 'region_name = regionOne')" -ge 1 ]
+      [ "$(oc get -n watcher-kuttl-default secret watcher-kuttl-api-config-data -o jsonpath='{.data.00-default\.conf}'|base64 -d|grep -c 'max_workers = 8')" == 1 ]
       # If we are running the container locally, skip following test
       if [ "$(oc get pods -n openstack-operators -o name -l openstack.org/operator-name=watcher)" == "" ]; then
           exit 0


### PR DESCRIPTION
The watcher taskflow workflow engine defaults to the number of CPUs, which can be too high in terms of cpu consumption in the decision-engine and in terms of parallel VM live migration for the cluster.

Set max_workers to 6 by default seems a balanced value that can be overrided using customServiceConfig.

Assisted-By: Cursor (claude-4.6-opus)
Fixes: [OSPRH-26677](https://redhat.atlassian.net/browse/OSPRH-26677)