### PR TITLE
kuttl: set empty MetricStorage networkAttachments

### DIFF
--- a/test/kuttl/test-suites/default/deps/telemetry.yaml
+++ b/test/kuttl/test-suites/default/deps/telemetry.yaml
@@ -7,6 +7,7 @@ spec:
     template:
       metricStorage:
         enabled: true
+        networkAttachments: []
         dashboardsEnabled: true
         monitoringStack:
           alertingEnabled: true


### PR DESCRIPTION
telemetry-operator PR #827 (https://github.com/openstack-k8s-operators/telemetry-operator/pull/827) adds a default networkAttachments on MetricStorage, which broke kuttl.

Set networkAttachments: [] under spec.telemetry.template.metricStorage in the shared OpenStackControlPlane deps.

Assisted-By: Cursor (Composer 2)

Depends-On: https://github.com/openstack-k8s-operators/openstack-operator/pull/1878