### PR TITLE
Revert pin coo version and set prometheus_write_path for COO 1.4.0

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -195,7 +195,7 @@
       cifmw_test_operator_tempest_external_plugin:
         - repository: "https://opendev.org/openstack/watcher-tempest-plugin.git"
           changeRepository: "https://review.opendev.org/openstack/watcher-tempest-plugin"
-          changeRefspec: "380572db57798530b64dcac14c6b01b0382c5d8e"
+          changeRefspec: "924551f526a40ed9328e0ff0a5d71acff9145950"
       watcher_scenario: "edpm-no-notifications"
 
 - job:

--- a/ci/playbooks/deploy_cluster_observability_operator.yaml
+++ b/ci/playbooks/deploy_cluster_observability_operator.yaml
@@ -22,33 +22,12 @@
             namespace: openshift-operators
           spec:
             channel: stable
-            installPlanApproval: Manual
-            startingCSV: cluster-observability-operator.v1.3.1
+            installPlanApproval: Automatic
             name: cluster-observability-operator
             source: redhat-operators
             sourceNamespace: openshift-marketplace
           EOF
       register: output
-
-    - name: Get and approve the installplan when the version is pinned
-      block:
-        - name: Get the installplan from the coo subscription
-          ansible.builtin.shell:
-            cmd: |
-              oc get installplan -n {{ _namespace }} | grep "cluster-observability-operator.v1.3.1" | awk '{print $1}'
-          retries: 15
-          delay: 20
-          register: coo_installplan
-          until: coo_installplan.stdout_lines | length != 0
-
-        - name: Show the coo_installplan from oc get installplan
-          ansible.builtin.debug:
-            var: coo_installplan
-
-        - name: Approve the installation
-          ansible.builtin.shell:
-            cmd: |
-              oc patch -n {{ _namespace }} installplan {{ coo_installplan.stdout }} --type='json' -p='[{"op": "replace", "path": "/spec/approved", "value":true}]'
 
       # need to have a wait here, since the csv is not created immediately. There is a slight delay, during which time, the oc wait command would fail, since there's no resource to watch
     - name: Wait for the required resource to be created

--- a/ci/tests/watcher-tempest-nfs.yml
+++ b/ci/tests/watcher-tempest-nfs.yml
@@ -27,6 +27,7 @@ cifmw_test_operator_tempest_tempestconf_config:
     optimize.prometheus_host metric-storage-prometheus.openstack.svc
     optimize.prometheus_ssl_enabled true
     optimize.prometheus_ssl_cert_dir /etc/prometheus/secrets/combined-ca-bundle
+    optimize.prometheus_write_path /
     optimize.podified_kubeconfig_path /home/zuul/.crc/machines/crc/kubeconfig
     optimize.podified_namespace openstack
     optimize.run_continuous_audit_tests true

--- a/ci/tests/watcher-tempest.yml
+++ b/ci/tests/watcher-tempest.yml
@@ -19,6 +19,7 @@ cifmw_test_operator_tempest_tempestconf_config:
     optimize.prometheus_host metric-storage-prometheus.openstack.svc
     optimize.prometheus_ssl_enabled true
     optimize.prometheus_ssl_cert_dir /etc/prometheus/secrets/combined-ca-bundle
+    optimize.prometheus_write_path /
     optimize.podified_kubeconfig_path /home/zuul/.crc/machines/crc/kubeconfig
     optimize.podified_namespace openstack
     optimize.run_continuous_audit_tests true


### PR DESCRIPTION
 Unpin c-o-o version and set prometheus_write_path for COO 1.4.0

The version of promtool included in cluster-observability-operator 1.4.0 requires the base prometheus url instead of the write api endpoint.

Update hash for watcher-tempest-plugin in epoxy jobs. We need it to get the new parameter prometheus_write_path so that we can unpin coo.

Depends-On: https://github.com/openstack-k8s-operators/watcher-operator/pull/359