### PR TITLE
Change nodeset that will not enforce to use specific cloud provider

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -14,7 +14,7 @@
 
 - job:
     name: watcher-operator-base
-    nodeset: centos-9-medium-2x-centos-9-crc-cloud-ocp-4-18-1-3xl-vexxhost
+    nodeset: centos-9-medium-2x-centos-9-crc-cloud-ocp-4-18-1-3xl
     parent: podified-multinode-edpm-deployment-crc-2comp
     description: |
       A multinode EDPM Zuul job which has one ansible controller, one


### PR DESCRIPTION
The RHOS DFG Infra team is decommisioning IBM private cloud. There is no need to make recognition per cloud provider when only one provider is available.