### PR TITLE
Remove suffix related to cloud provider recognition

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -99,7 +99,7 @@
 
 - job:
     name: watcher-operator-kuttl
-    nodeset: centos-9-medium-crc-cloud-ocp-4-18-1-3xl-vexxhost
+    nodeset: centos-9-medium-crc-cloud-ocp-4-18-1-3xl
     dependencies: ["openstack-meta-content-provider-master"]
     parent: cifmw-multinode-kuttl-operator-target
     description: |
@@ -204,7 +204,7 @@
     description: |
       watcher-operator-validation qualification with OCP 4.16.
       No dedicated RabbitMQ notifications broker is enabled on this job.
-    nodeset: centos-9-medium-2x-centos-9-crc-extracted-2-39-0-3xl-vexxhost
+    nodeset: centos-9-medium-2x-centos-9-crc-extracted-2-39-0-3xl
 
 ##########################################################
 #                                                        #
@@ -215,7 +215,7 @@
     name: openstack-meta-content-provider-master
     description: |
       A zuul job building content from OpenDev master release on CentOS Stream 10.
-    nodeset: centos-stream-10-vexxhost
+    nodeset: centos-stream-10
     parent: openstack-meta-content-provider
     vars:
       cifmw_install_yamls_sdk_version: v1.41.1

--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -14,7 +14,7 @@
 
 - job:
     name: watcher-operator-base
-    nodeset: centos-9-medium-2x-centos-9-crc-cloud-ocp-4-18-1-3xl-vexxhost
+    nodeset: centos-9-medium-2x-centos-9-crc-cloud-ocp-4-18-1-3xl
     parent: podified-multinode-edpm-deployment-crc-2comp
     description: |
       A multinode EDPM Zuul job which has one ansible controller, one


### PR DESCRIPTION
There is no need to keep the suffix that was only done for
making recognition to enforce job to be spawned on one of the cloud
provider.

Depends-On: https://github.com/openstack-k8s-operators/ci-framework/pull/3852