### PR TITLE
Migrate epoxy validation job from OCP 4.16 to 4.20

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -14,7 +14,7 @@
 
 - job:
     name: watcher-operator-base
-    nodeset: centos-9-medium-2x-centos-9-crc-cloud-ocp-4-18-1-3xl
+    nodeset: centos-9-medium-2x-centos-9-crc-cloud-ocp-4-20-1-3xl
     parent: podified-multinode-edpm-deployment-crc-2comp
     description: |
       A multinode EDPM Zuul job which has one ansible controller, one
@@ -199,12 +199,12 @@
       watcher_scenario: "edpm-no-notifications"
 
 - job:
-    name: watcher-operator-validation-epoxy-ocp4-16
+    name: watcher-operator-validation-epoxy-ocp4-18
     parent: watcher-operator-validation-epoxy
     description: |
-      watcher-operator-validation qualification with OCP 4.16.
+      watcher-operator-validation qualification with OCP 4.18.
       No dedicated RabbitMQ notifications broker is enabled on this job.
-    nodeset: centos-9-medium-2x-centos-9-crc-extracted-2-39-0-3xl
+    nodeset: centos-9-medium-2x-centos-9-crc-cloud-ocp-4-18-1-3xl
 
 ##########################################################
 #                                                        #
@@ -314,7 +314,7 @@
       jobs:
         - openstack-meta-content-provider-epoxy
         - watcher-operator-validation-epoxy
-        - watcher-operator-validation-epoxy-ocp4-16
+        - watcher-operator-validation-epoxy-ocp4-18
 
 - project-template:
     name: opendev-watcher-edpm-pipeline


### PR DESCRIPTION
Replace watcher-operator-validation-epoxy-ocp4-16 with
watcher-operator-validation-epoxy-ocp4-18

Move watcher-operator-base from 4.18 to 4.20, so
now default OCP version will be 4.20 except on
watcher-operator-validation-epoxy-ocp4-18

Assisted-by: claude
Signed-off-by: morenod <dsanzmor@redhat.com>