### PR TITLE
Disable barbican service in scenario applied to centos10-master

### DIFF
--- a/ci/scenarios/edpm.yml
+++ b/ci/scenarios/edpm.yml
@@ -167,6 +167,17 @@ cifmw_edpm_prepare_kustomizations:
         target:
           kind: OpenStackControlPlane
 
+      - patch: |-
+          apiVersion: core.openstack.org/v1beta1
+          kind: OpenStackControlPlane
+          metadata:
+            name: controlplane
+          spec:
+            barbican:
+              enabled: false
+        target:
+          kind: OpenStackControlPlane
+
 cifmw_edpm_prepare_timeout: 60
 
 cifmw_install_yamls_whitelisted_vars:


### PR DESCRIPTION
Currently, the deployment of barbican in master is broken [1]. This patch is disabling barbican in the scenario applied to the affected job, watcher-operator-validation-master.

[1] https://bugs.launchpad.net/barbican/+bug/2152897