### PR TITLE
DNM Revert "Disable barbican service in scenario applied to centos10-…

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -5,7 +5,6 @@
     merge-mode: rebase
     templates:
       - opendev-master-watcher-operator-pipeline
-      - opendev-epoxy-watcher-operator-pipeline
     github-check:
       jobs:
         - noop

--- a/ci/scenarios/edpm.yml
+++ b/ci/scenarios/edpm.yml
@@ -167,17 +167,6 @@ cifmw_edpm_prepare_kustomizations:
         target:
           kind: OpenStackControlPlane
 
-      - patch: |-
-          apiVersion: core.openstack.org/v1beta1
-          kind: OpenStackControlPlane
-          metadata:
-            name: controlplane
-          spec:
-            barbican:
-              enabled: false
-        target:
-          kind: OpenStackControlPlane
-
 cifmw_edpm_prepare_timeout: 60
 
 cifmw_install_yamls_whitelisted_vars:


### PR DESCRIPTION
…master"

This reverts commit b85e44111e53289428e82d415e9e0623444dad82.

Depends-On: https://review.opendev.org/c/openstack/barbican/+/990084