### PR TITLE
Set service_type in [keystone_authtoken] for access rule validation

### DIFF
--- a/templates/00-default.conf
+++ b/templates/00-default.conf
@@ -62,6 +62,7 @@ auth_type = password
 {{ end }}
 auth_url = {{ .KeystoneAuthURL }}
 interface = internal
+service_type = infra-optim
 region_name = {{ .Region }}
 {{ if .CaFilePath }}
 cafile = {{ .CaFilePath }}


### PR DESCRIPTION
Without service_type configured, keystonemiddleware cannot validate application credentials with custom access rules, causing HTTP 401 for end users.

Closes: [OSPRH-22365](https://redhat.atlassian.net/browse/OSPRH-22365)