### PR TITLE
Fix client IP logging in Watcher API VirtualHost

### DIFF
--- a/templates/watcherapi/config/10-watcher-wsgi-main.conf
+++ b/templates/watcherapi/config/10-watcher-wsgi-main.conf
@@ -21,6 +21,7 @@
   ## Logging
   ErrorLog /dev/stdout
   ServerSignature Off
+  SetEnvIf X-Forwarded-For "^.*\..*\..*\..*" forwarded
   CustomLog /dev/stdout combined env=!forwarded
   CustomLog /dev/stdout proxy env=forwarded
   ## set watcher log level to debug

--- a/templates/watcherapi/config/httpd.conf
+++ b/templates/watcherapi/config/httpd.conf
@@ -36,15 +36,12 @@ AccessFileName .htaccess
         Include "/etc/httpd/conf.modules.d/*.conf"
         Include "/etc/httpd/conf.d/*.conf"
 
-        LogFormat "%a %l %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-Agent}i\"" combined
-        LogFormat "%a %l %u %t \"%r\" %>s %b" common
-        LogFormat "%{Referer}i -> %U" referer
-        LogFormat "%{User-agent}i" agent
-        LogFormat "%{X-Forwarded-For}i %l %u %t \"%r\" %s %b \"%{Referer}i\" \"%{User-agent}i\"" forwarded
+        LogFormat "%h %l %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-Agent}i\"" combined
+        LogFormat "%{X-Forwarded-For}i %l %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-Agent}i\"" proxy
 
-        ErrorLog /dev/stderr
-        TransferLog /dev/stdout
+        SetEnvIf X-Forwarded-For "^.*\..*\..*\..*" forwarded
+        ErrorLog /dev/stdout
         CustomLog /dev/stdout combined env=!forwarded
-        CustomLog /dev/stdout proxy env=!forwarded
+        CustomLog /dev/stdout proxy env=forwarded
         ## set default apache log level to infor from warning
         LogLevel info


### PR DESCRIPTION
Align watcher `httpd` `logging` with the  existing operator pattern:
- Add missing `SetEnvIf X-Forwarded-For` in the `VirtualHost` block
- Normalize server-level `httpd.conf`: use the existing pattern for `LogFormat` names (`combined`, `proxy`), and log to `/dev/stdout` so logs are visible via `oc logs -f`

Related: [OSPRH-32126](https://redhat.atlassian.net/browse/OSPRH-32126)